### PR TITLE
Added missing smtp user/password to template file.

### DIFF
--- a/templates/ssm_sensitive_values_tower.json
+++ b/templates/ssm_sensitive_values_tower.json
@@ -23,6 +23,16 @@
 		"ssm_key": 	"/config/tower-dev/micronaut/security/token/jwt/generator/refresh-token/secret",
 		"value": 	"CHANGE_ME_SEE_SEQERA_DOCS (must be same value as JWT_SECRET_1)"
 	},
+	"TOWER_SMTP_USER": { 
+		"ssm_key": 	"/config/tower-dev/mail/smtp/user",
+		"value": 	"REPLACE_ME_IF_NECESSARY",
+		"description": "The SMTP user."
+	},
+        "TOWER_SMTP_PASSWORD": { 
+		"ssm_key": 	"/config/tower-dev/mail/smtp/password",
+		"value": 	"REPLACE_ME_IF_NECESSARY",
+		"description": "The SMTP password."
+	},
 	"TOWER_DB_USER": { 
 		"ssm_key": 	"/config/tower-dev/datasources/default/username",
 		"value": 	"CHANGE_ME_SEE_SEQERA_DOCS"


### PR DESCRIPTION
@schaluva -- another one (please). It can be tested by adding the two extra secret entries and then no using the native IAM SES integration.