### PR TITLE
Gwright99/1 replace mysql client

### DIFF
--- a/assets/src/ansible/01_load_system_packages.yml
+++ b/assets/src/ansible/01_load_system_packages.yml
@@ -54,33 +54,33 @@
       append: yes
 
 
-  - name: MySQL - Get RPM
-    # https://serverfault.com/questions/946219/how-to-install-mysql-server-using-ansible-playbook
-    ansible.builtin.shell: |
-      mkdir -p /opt/mysql && cd /opt/mysql
-      rm -rf /opt/mysql/mysql*.rpm*
+  # - name: MySQL - Get RPM
+  #   # https://serverfault.com/questions/946219/how-to-install-mysql-server-using-ansible-playbook
+  #   ansible.builtin.shell: |
+  #     mkdir -p /opt/mysql && cd /opt/mysql
+  #     rm -rf /opt/mysql/mysql*.rpm*
 
-      # Stopped working ~Jan 15/24. Commented out but keeping for reference.
-      # wget https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm
-      # rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
+  #     # Stopped working ~Jan 15/24. Commented out but keeping for reference.
+  #     # wget https://dev.mysql.com/get/mysql80-community-release-el9-1.noarch.rpm
+  #     # rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2022
 
-      # Sudo suddenly required to make this work. Very strange. key must be imported first (Jan 16/24)
-      rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2023
-      wget https://dev.mysql.com/get/mysql80-community-release-el9-5.noarch.rpm
-      yum install -y mysql80-community-release-el9-5.noarch.rpm
+  #     # Sudo suddenly required to make this work. Very strange. key must be imported first (Jan 16/24)
+  #     rpm --import https://repo.mysql.com/RPM-GPG-KEY-mysql-2023
+  #     wget https://dev.mysql.com/get/mysql80-community-release-el9-5.noarch.rpm
+  #     yum install -y mysql80-community-release-el9-5.noarch.rpm
 
-  #This stopped working when the RPM / GPG problem (above) happened. Commented out but kept for reference.
-  #Consider replacing this whole thing with a MySQL docker container instead to avoid future headaches.
-  - name: MySQL - Install RPM
-    ansible.builtin.yum:
-      # name: /opt/mysql/mysql80-community-release-el9-1.noarch.rpm
-      name: /opt/mysql/mysql80-community-release-el9-5.noarch.rpm
-      state: present
+  # #This stopped working when the RPM / GPG problem (above) happened. Commented out but kept for reference.
+  # #Consider replacing this whole thing with a MySQL docker container instead to avoid future headaches.
+  # - name: MySQL - Install RPM
+  #   ansible.builtin.yum:
+  #     # name: /opt/mysql/mysql80-community-release-el9-1.noarch.rpm
+  #     name: /opt/mysql/mysql80-community-release-el9-5.noarch.rpm
+  #     state: present
 
-  - name: MySQL - Install Client
-    ansible.builtin.yum:
-      name: mysql-community-client
-      state: installed
+  # - name: MySQL - Install Client
+  #   ansible.builtin.yum:
+  #     name: mysql-community-client
+  #     state: installed
 
 
   - name: Install Java Corretto 17

--- a/assets/src/python/get_access_token.py
+++ b/assets/src/python/get_access_token.py
@@ -6,7 +6,9 @@ import json
 import os
 import subprocess
 
+
 SEQERAKIT_USE_HOSTS_FILE = os.getenv('SEQERAKIT_USE_HOSTS_FILE')
+
 if SEQERAKIT_USE_HOSTS_FILE == "true":
     TOWER_API_ENDPOINT = f"http:/localhost:8000/api"
 else:
@@ -18,17 +20,19 @@ EMAIL_ADDRESS = ''
 
 
 # Grab first TOWER_ROOT_USERS entry for login purposes
-key = "TOWER_ROOT_USERS="
-#  Hardcoding path bad, but this is hardcoded lots of other places so ok for now.
+# Hardcoding path bad, but this is hardcoded lots of other places so ok for now.
 with open('/home/ec2-user/tower.env', 'r') as file:
     '''Find the TOWER_ROOT_USER entry, split on comma if multiple value, and grab first entry'''
     lines = file.readlines()
     
     for line in lines:
-        if line.startswith(key):
+        if line.startswith("TOWER_ROOT_USERS="):
             values = line.split('=')[1]
             try:
                 EMAIL_ADDRESS = values.split(',')[0]
+                EMAIL_ADRRESS = EMAIL_ADDRESS.strip()
+                break
+
             except Exception as e:
                 EMAIL_ADDRESS = values
 
@@ -37,13 +41,14 @@ with open('/home/ec2-user/tower.env', 'r') as file:
 
 
 # Need to properly escape doublequotes for json payload. Strip \n off constant since that breaks curl.
-login_payload =  {"email": EMAIL_ADDRESS.strip()}
+login_payload =  {"email": EMAIL_ADDRESS}
+# login_payload =  {"email": EMAIL_ADDRESS.strip()}
 login_payload = json.dumps(login_payload)
 print(login_payload)
 
 login_command = f"curl -Ss '{TOWER_API_ENDPOINT}/gate/access' -H 'Content-Type: application/json' -d '" + login_payload + "' -o /dev/null"
 login = subprocess.run( login_command, shell=True, text=True, capture_output=False )
-print(login_payload)
+print(login)
 
 # Get auth token from database
 is_external_db_in_use = os.getenv("DB_POPULATE_EXTERNAL_INSTANCE")

--- a/assets/src/python/get_access_token.py
+++ b/assets/src/python/get_access_token.py
@@ -66,19 +66,18 @@ if str(is_external_db_in_use) == "true":
     )
     tower_db_password = tower_db_password.stdout.replace('\n', '')
 
-    
-    
-    docker_run = f"docker run --rm -t -e MYSQL_PWD={tower_db_password} --entrypoint /bin/bash mysql:8.0"
-    mysql_conn = f"mysql --host {os.getenv('DB_URL')} --port=3306 --user={tower_db_user}"
-    query      = f"use tower; select auth_token FROM tw_user WHERE email=\"{EMAIL_ADDRESS}\";"
 
-    full_conn = f"{docker_run} -c \"{mysql_conn} <<< '{query}' \" "     #f"| sed -n '2p'"
+    # docker_run = f"docker run --rm -t -e MYSQL_PWD={tower_db_password} --entrypoint /bin/bash mysql:8.0 --name=token_helper"
+    # mysql_conn = fr"""mysql --host {os.getenv('DB_URL')} --port=3306 --user={tower_db_user} <<< 'use tower; select auth_token FROM tw_user WHERE email="{EMAIL_ADDRESS}";'"""
+    # full_conn = f"""{docker_run} -c "{mysql_conn}" """      #f"| sed -n '2p'"""
+
+    rds_query = f"""docker run --rm -t -e MYSQL_PWD={tower_db_password} mysql:8.0 mysql --host {os.getenv('DB_URL')} --port=3306 -utower --silent --skip-column-names --execute 'select auth_token FROM tower.tw_user WHERE email="{EMAIL_ADDRESS}";' """
 
     auth_token = subprocess.run(
         # Old call was too brittle -- assumed the first root user would be the first DB entry. Only true for first time greenfield deployments.
         # Modified SQL to search the db table for the same email that we grabbed above for initial login
 
-        [full_conn],
+        [rds_query],
         shell=True, text=True, capture_output=True
     )
 


### PR DESCRIPTION
Overhauled Ansible logic so that we use the same `mysql:8.0` container most folks will use when doing containerized Tower deployments instead of downloading a repo-based download of a `mysql-client` binary.

####How to test
1. Set `flag_create_external_db                 = true`
2. Set `flag_run_seqerakit                      = true`
3. Make sure at least one `tower_root_users ` is specified
4. Run deployment and see if Seqerakit can successfully create resources.