### PR TITLE
Fixed Groundswell DB URL which I broke with v24.1.1 connection string…

### DIFF
--- a/000_main.tf
+++ b/000_main.tf
@@ -294,6 +294,8 @@ locals {
   tower_db_root = ( var.flag_use_container_db == true? var.tower_db_url : module.rds[0].db_instance_address )
   tower_db_url = "${local.tower_db_root}/${var.db_database_name}${data.external.generate_db_connection_string.result.value}"
 
+  swell_db_url = "${local.tower_db_root}/${var.swell_database_name}${data.external.generate_db_connection_string.result.value}"
+
 
   # Redis
   # ---------------------------------------------------------------------------------------

--- a/009_define_file_templates.tf
+++ b/009_define_file_templates.tf
@@ -95,7 +95,8 @@ locals {
 
       swell_db_user       = local.groundswell_secrets["SWELL_DB_USER"]["value"],
       swell_db_password   = local.groundswell_secrets["SWELL_DB_PASSWORD"]["value"],
-      swell_database_name = var.swell_database_name
+      swell_database_name = var.swell_database_name,
+      db_database_name  = var.db_database_name,
     }
   )
 
@@ -108,7 +109,8 @@ locals {
 
       swell_db_user       = local.groundswell_secrets["SWELL_DB_USER"]["value"],
       swell_db_password   = local.groundswell_secrets["SWELL_DB_PASSWORD"]["value"],
-      swell_database_name = var.swell_database_name,
+      # swell_database_name = var.swell_database_name,
+      swell_db_url = local.swell_db_url,
 
       flag_use_container_db = var.flag_use_container_db,
       db_engine_version     = var.db_engine_version

--- a/assets/src/groundswell_config/groundswell.env.tpl
+++ b/assets/src/groundswell_config/groundswell.env.tpl
@@ -17,11 +17,7 @@ SWELL_API_TRAIN_BATCH_SIZE=1000
 SWELL_API_PREDICT_FRACTIONAL_CPUS=false
 
 # Database settings
-%{ if flag_use_container_db == false && startswith(db_engine_version, "8") == false ~}
-SWELL_DB_URL=jdbc:mysql://${tower_db_url}/${swell_database_name}
-%{~ else ~}
-SWELL_DB_URL=jdbc:mysql://${tower_db_url}/${swell_database_name}?allowPublicKeyRetrieval=true&useSSL=false
-%{ endif }
+SWELL_DB_URL=jdbc:mysql://${swell_db_url}
 SWELL_DB_USER=${swell_db_user}
 SWELL_DB_PASSWORD=${swell_db_password}
 SWELL_DB_DIALECT=mysql


### PR DESCRIPTION
@schaluva - how to test:

- With 1.3 release:
    - Use either kind of db (container / RDS).
    - Ensure Groundswell feature is activated.
    - Once application is stood up jump between the Launch tab and other tabs. You should see a spinning wheel ~5+ seconds on the Launch tab (_and error messages in the container logs re: groundswell connectivity).

- With this PR:
    - Repeat steps above.
    - This time, Launchpad should be quite responsive and no groundswell error in logs.  