### PR TITLE
Made ALB Ingress CIDR rule more flexible and fixed SSH ingress rule bug.

### DIFF
--- a/000_main.tf
+++ b/000_main.tf
@@ -223,11 +223,9 @@ locals {
 
   alb_ingress_cidrs = (
     var.flag_make_instance_public == true || var.flag_make_instance_private_behind_public_alb == true ? var.sg_ingress_cidrs :
-    var.flag_make_instance_private == true && var.flag_create_new_vpc == true ? [var.vpc_new_cidr_range] :
-    var.flag_make_instance_private == true && var.flag_use_existing_vpc == true ? [data.aws_vpc.preexisting.cidr_block] :
-    var.flag_private_tower_without_eice == true && var.flag_use_existing_vpc == true ? [data.aws_vpc.preexisting.cidr_block] :
-    # DELETE THIS
-    var.flag_private_tower_without_eice == true && var.flag_create_new_vpc == true ? [data.aws_vpc.preexisting.cidr_block] :
+    var.flag_make_instance_private == true && var.flag_create_new_vpc == true ? concat([var.vpc_new_cidr_range], var.sg_ingress_cidrs):
+    var.flag_make_instance_private == true && var.flag_use_existing_vpc == true ? concat([data.aws_vpc.preexisting.cidr_block], var.sg_ingress_cidrs) :
+    var.flag_private_tower_without_eice == true && var.flag_use_existing_vpc == true ? concat([data.aws_vpc.preexisting.cidr_block], var.sg_ingress_cidrs) :
     ["No CIDR block found"]
   )
 

--- a/002_security_groups.tf
+++ b/002_security_groups.tf
@@ -16,7 +16,7 @@ module "tower_eice_ingress_sg" {
   description = "Allowed ingress CIDRS EC2 Instance Connect endpoint."
 
   vpc_id              = local.vpc_id
-  ingress_cidr_blocks = var.sg_ingress_cidrs
+  ingress_cidr_blocks = var.sg_ssh_cidrs
   ingress_rules       = ["ssh-tcp"]
 }
 
@@ -44,7 +44,7 @@ module "tower_ec2_ssh_sg" {
   description = "Allowed SSH ingress to EC2 instance (EICE only)."
 
   vpc_id              = local.vpc_id
-  ingress_cidr_blocks = var.sg_ingress_cidrs
+  ingress_cidr_blocks = var.sg_ssh_cidrs
   ingress_rules       = ["ssh-tcp"]
 }
 
@@ -121,6 +121,7 @@ module "tower_alb_sg" {
   ingress_rules       = ["https-443-tcp", "http-80-tcp"]
   egress_rules        = var.sg_egress_tower_alb
 }
+
 
 module "tower_ec2_alb_connect_sg" {
   source  = "terraform-aws-modules/security-group/aws"

--- a/templates/TEMPLATE_terraform.tfvars
+++ b/templates/TEMPLATE_terraform.tfvars
@@ -342,7 +342,9 @@ vpc_interface_endpoints_batch             = []
 ## Security Group - Transaction Sources
 ## ------------------------------------------------------------------------------------
 These settings control which IPs are allowed to call the VM / ALB. For ease of initial setup
-these are *very* loose. Consider tightening if your deployment model allows it. 
+these are *very* loose. Consider tightening if your deployment model allows it. The arrays can 
+contain multiple entries if necessary (e.g. you might wish to both your VPN CIDR and home IP to
+be able to make HTTPS calls / SSH connections).
 
 If using EICE, please note that individuals must have IAM rights to interact with the endpoint 
 prior to any SSH transaction being allowed against the VM. 


### PR DESCRIPTION
## How to test:

1. Ensure all CIDR entries specified in `var.sg_ingress_cidrs` are represented in ALB inbound security rules when:
    1. `var.flag_make_instance_private == true`  or 
    2. `var.flag_private_tower_without_eice == true`
    
2. Ensure SSH file copy still works even if `var.sg_ingress_cidrs` is set to a fictitious value (_e.g. 10.67.2.1_).

3. Remove `0.0.0.0/0` from `var.sg_ingress_cidrs` value and replace with a ~VPN CIDR block~ the CIDR block of the VPC which the VPN is connecting your local machine to.