### PR TITLE
Removed jdbc prefix which broke Groundswell migration.

### DIFF
--- a/assets/src/groundswell_config/groundswell.env.tpl
+++ b/assets/src/groundswell_config/groundswell.env.tpl
@@ -17,7 +17,8 @@ SWELL_API_TRAIN_BATCH_SIZE=1000
 SWELL_API_PREDICT_FRACTIONAL_CPUS=false
 
 # Database settings
-SWELL_DB_URL=jdbc:mysql://${swell_db_url}
+# NOTE: DO NOT ADD 'jdbc' at the front (breaks migration)
+SWELL_DB_URL=mysql://${swell_db_url}
 SWELL_DB_USER=${swell_db_user}
 SWELL_DB_PASSWORD=${swell_db_password}
 SWELL_DB_DIALECT=mysql


### PR DESCRIPTION
How to test:

## Failing Scenario
1. Add `jdbc://` as left-most prefix on `SWELL_DB_URL` in `assets/src/groundswell_config/groundswell.env.tpl`.
2. Deploy application.
3. Confirm that Groundswell container logs emit error related to "driver".
4. Log into database and confirm that `swell` schema has no associated tables.

## Successful Scenario
1. Ensure `mysql://` is left-most prefix on `SWELL_DB_URL` in `assets/src/groundswell_config/groundswell.env.tpl`.
2. Deploy application.
3. Confirm that Groundswell container logs does not contain error related to "driver".
4. Log into database and confirm that `swell` schema has associated tables.

```mysql
mysql> use swell;                                                                                                                                                                                                                            Reading table information for completion of table and column names                                                                                                                                                                           You can turn off this feature to get a quicker startup with -A                                                                                                                                                                                                                                                                                                                                                                                                                            Database changed                                                                                                                                                                                                                             mysql> show tables;
+-------------------+
| Tables_in_swell   |
+-------------------+
| MIGTOOL_HISTORY   |
| sw_resource_model |
+-------------------+
2 rows in set (0.01 sec) 
```