### PR TITLE
add auth oidc micronaut env for google

### DIFF
--- a/000_main.tf
+++ b/000_main.tf
@@ -284,7 +284,8 @@ locals {
   # OIDC
   # ---------------------------------------------------------------------------------------
   # If flags are set, populate local with keyword for MICRONAUT_ENVIRONMENTS inclusion. If not, blank string.
-  oidc_auth   = var.flag_oidc_use_generic == true || var.flag_oidc_use_google == true ? ",auth-oidc" : ""
+  oidc_auth   = var.flag_oidc_use_generic == true ? ",auth-oidc" : ""
+  oidc_google = var.flag_oidc_use_google == true ? ",auth-google" : ""
   oidc_github = var.flag_oidc_use_github == true ? ",auth-github" : ""
 
 

--- a/009_define_file_templates.tf
+++ b/009_define_file_templates.tf
@@ -160,6 +160,7 @@ locals {
     {
       docker_version                      = var.tower_container_version,
       auth_oidc                           = local.oidc_auth,
+      auth_google                         = local.oidc_google,
       auth_github                         = local.oidc_github,
 
       db_database_name                    = var.db_database_name

--- a/assets/src/docker_compose/docker-compose.yml.tpl
+++ b/assets/src/docker_compose/docker-compose.yml.tpl
@@ -110,7 +110,7 @@ services:
       - tower.env
     environment:
       # Micronaut environments are required. Do not edit these value
-      - MICRONAUT_ENVIRONMENTS=prod,redis,cron${auth_oidc}${auth_github}
+      - MICRONAUT_ENVIRONMENTS=prod,redis,cron${auth_oidc}${auth_github}${auth_google}
     restart: always
     depends_on:
       migrate:
@@ -136,7 +136,7 @@ services:
       - tower.env
     environment:
       # Micronaut environments are required. Do not edit these value
-      - MICRONAUT_ENVIRONMENTS=prod,redis,cron${auth_oidc}${auth_github}
+      - MICRONAUT_ENVIRONMENTS=prod,redis,cron${auth_oidc}${auth_github}${auth_google}
     restart: always
 %{ if flag_use_container_db == true || flag_use_container_redis == true ~}
     depends_on:
@@ -170,7 +170,7 @@ services:
     env_file:
       - tower.env
     environment:
-      - MICRONAUT_ENVIRONMENTS=prod,redis,ha${auth_oidc}${auth_github}
+      - MICRONAUT_ENVIRONMENTS=prod,redis,ha${auth_oidc}${auth_github}${auth_google}
     restart: always
     depends_on:
 %{ if flag_use_container_db == true ~}


### PR DESCRIPTION
Bug: Setting `flag_oidc_use_google=true` didn't actually activate the "Sign in with Google" button.   Root cause was a change in how `auth-google` was added to `MICRONAUT_ENVIRONMENTS`.

This PR fixes the issue. @gwright99 created this on behalf of @schaluva.