### PR TITLE
Fix Release 1.6.0 problems (Part 2)

### DIFF
--- a/002_security_groups.tf
+++ b/002_security_groups.tf
@@ -311,7 +311,8 @@ what the impact would be on sites that:
 In order to support an orderly transition, I am reintroducing ALL the old 1.5.0 SGs. The reintroduction will ensure that any of the
 existing deloyments still find the assets they need prior to upgrade and then be able to transition to the new SG model introduced in 1.6.0.
 
-In a subsequent release, the resources below will be removed and documentation will clearly reflect that < 1.6.1 needs to upgrade to 1
+In a subsequent release, the resources below will be removed and documentation will clearly reflect that < 1.6.1 needs to upgrade to 1.6.1 
+prior to upgrading to any future release > 1.6.1
 
 */
 
@@ -393,8 +394,8 @@ module "tower_ec2_direct_connect_sg" {
   name        = "${local.global_prefix}_ec2_direct_connect_sg"
   description = "Direct HTTP to Tower EC2 host when Connect active."
 
-  vpc_id              = local.vpc_id
-  ingress_with_cidr_blocks = local.tower_ec2_direct_connect_sg_final
+  vpc_id = local.vpc_id
+  # ingress_with_cidr_blocks = ["local.tower_ec2_direct_connect_sg_final"]
 }
 
 
@@ -442,11 +443,11 @@ module "tower_ec2_alb_connect_sg" {
   name        = "${local.global_prefix}_ec2_alb_connect_sg"
   description = "Direct HTTP to Tower EC2 host when Connect active."
 
-  vpc_id              = local.vpc_id
+  vpc_id = local.vpc_id
   # computed_ingress_with_cidr_blocks = local.tower_ec2_alb_connect_sg_final
   # computed_ingress_with_cidr_blocks = local.tower_ec2_alb_connect_sg_final
-  computed_ingress_with_source_security_group_id= local.tower_ec2_alb_connect_sg_final
-  number_of_computed_ingress_with_source_security_group_id = 1
+  #computed_ingress_with_source_security_group_id= local.tower_ec2_alb_connect_sg_final
+  # number_of_computed_ingress_with_source_security_group_id = 1
 }
 
 ## ------------------------------------------------------------------------------------

--- a/002_security_groups.tf
+++ b/002_security_groups.tf
@@ -292,3 +292,240 @@ module "sg_vpc_endpoint" {
   ingress_rules       = ["all-all"]
   egress_rules        = var.sg_egress_interface_endpoint
 }
+
+
+/*
+## ------------------------------------------------------------------------------------
+## AUGUST 15, 2025 - THIS SECTION DEPRECATED BUT NEEDS TO EXIST FOR REASONS
+## ------------------------------------------------------------------------------------
+@gwright99 did something stupid between Release 1.5.0 and 1.6.0:
+- [1.5.0](https://github.com/seqeralabs/cx-field-tools-installer/blob/1.5.0/002_security_groups.tf)
+- [1.6.0](https://github.com/seqeralabs/cx-field-tools-installer/blob/1.6.0/002_security_groups.tf)
+
+I renamed and consolidated many of the Security Groups for easier management and cleaner naming, but didn't consider
+what the impact would be on sites that:
+
+1) Reused these assets in other parts of the AWS Account not tied to the installer.
+2) Had an instance running on a VM with an old AMI, which would cause TF to instantiate a new VM and SGs alongside the old one.
+
+In order to support an orderly transition, I am reintroducing ALL the old 1.5.0 SGs. The reintroduction will ensure that any of the
+existing deloyments still find the assets they need prior to upgrade and then be able to transition to the new SG model introduced in 1.6.0.
+
+In a subsequent release, the resources below will be removed and documentation will clearly reflect that < 1.6.1 needs to upgrade to 1
+
+*/
+
+## ------------------------------------------------------------------------------------
+## Instance Connect Endpoint Controls
+## ------------------------------------------------------------------------------------
+module "tower_eice_ingress_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_eice_sg"
+  description = "Allowed ingress CIDRS EC2 Instance Connect endpoint."
+
+  vpc_id              = local.vpc_id
+  ingress_cidr_blocks = var.sg_ssh_cidrs
+  ingress_rules       = ["ssh-tcp"]
+}
+
+
+module "tower_eice_egress_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_ec2_egress_sg"
+  description = "Allowed egress CIDRS EC2 Instance Connect endpoint."
+
+  vpc_id       = local.vpc_id
+  egress_rules = var.sg_egress_eice
+}
+
+
+## ------------------------------------------------------------------------------------
+## EC2 Controls
+## ------------------------------------------------------------------------------------
+module "tower_ec2_ssh_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_ec2_ssh_sg"
+  description = "Allowed SSH ingress to EC2 instance (EICE only)."
+
+  vpc_id              = local.vpc_id
+  ingress_cidr_blocks = var.sg_ssh_cidrs
+  ingress_rules       = ["ssh-tcp"]
+}
+
+
+module "tower_ec2_egress_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_ec2_egress_sg"
+  description = "Tower EC2 host egress."
+
+  vpc_id              = local.vpc_id
+  ingress_cidr_blocks = var.sg_ingress_cidrs
+  egress_rules        = var.sg_egress_tower_ec2
+}
+
+
+module "tower_ec2_direct_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_ec2_direct_sg"
+  description = "Direct HTTP to Tower EC2 host."
+
+  vpc_id              = local.vpc_id
+  ingress_cidr_blocks = var.sg_ingress_cidrs
+  ingress_rules       = ["https-443-tcp", "http-80-tcp", "splunk-web-tcp"]
+}
+
+module "tower_ec2_direct_connect_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  count = var.flag_enable_data_studio == true ? 1 : 0
+
+  name        = "${local.global_prefix}_ec2_direct_connect_sg"
+  description = "Direct HTTP to Tower EC2 host when Connect active."
+
+  vpc_id              = local.vpc_id
+  ingress_with_cidr_blocks = local.tower_ec2_direct_connect_sg_final
+}
+
+
+module "tower_ec2_alb_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_ec2_alb_sg"
+  description = "ALB HTTP to Tower EC2 host."
+
+  vpc_id = local.vpc_id
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "splunk-web-tcp"
+      source_security_group_id = module.tower_alb_sg.security_group_id
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+}
+
+
+## ------------------------------------------------------------------------------------
+## ALB Controls
+## ------------------------------------------------------------------------------------
+module "tower_alb_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_alb_sg"
+  description = "HTTP to Tower ALB instance."
+
+  vpc_id              = local.vpc_id
+  ingress_cidr_blocks = local.alb_ingress_cidrs #var.sg_ingress_cidrs
+  ingress_rules       = ["https-443-tcp", "http-80-tcp"]
+  egress_rules        = var.sg_egress_tower_alb
+}
+
+
+module "tower_ec2_alb_connect_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  count = var.flag_enable_data_studio == true ? 1 : 0
+
+  name        = "${local.global_prefix}_ec2_alb_connect_sg"
+  description = "Direct HTTP to Tower EC2 host when Connect active."
+
+  vpc_id              = local.vpc_id
+  # computed_ingress_with_cidr_blocks = local.tower_ec2_alb_connect_sg_final
+  # computed_ingress_with_cidr_blocks = local.tower_ec2_alb_connect_sg_final
+  computed_ingress_with_source_security_group_id= local.tower_ec2_alb_connect_sg_final
+  number_of_computed_ingress_with_source_security_group_id = 1
+}
+
+## ------------------------------------------------------------------------------------
+## DB Controls
+## ------------------------------------------------------------------------------------
+module "tower_db_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_rds_sg"
+  description = "Security group for Tower RDS instance."
+
+  vpc_id = local.vpc_id
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "mysql-tcp"
+      source_security_group_id = module.tower_ec2_egress_sg.security_group_id
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+}
+
+
+## ------------------------------------------------------------------------------------
+## AWS Batch Security Groups
+## ------------------------------------------------------------------------------------
+module "tower_batch_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_batch_sg"
+  description = "Security group for Tower Batch instance."
+
+  vpc_id       = local.vpc_id
+  egress_rules = var.sg_egress_batch_ec2
+
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "ssh-tcp"
+      source_security_group_id = module.tower_ec2_egress_sg.security_group_id
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+}
+
+
+## ------------------------------------------------------------------------------------
+## Elasticache (Redis) Controls
+## ------------------------------------------------------------------------------------
+module "tower_redis_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_redis_sg"
+  description = "Security group for Tower Elasticache instance."
+
+  vpc_id = local.vpc_id
+  computed_ingress_with_source_security_group_id = [
+    {
+      rule                     = "redis-tcp"
+      source_security_group_id = module.tower_ec2_egress_sg.security_group_id
+    }
+  ]
+  number_of_computed_ingress_with_source_security_group_id = 1
+}
+
+
+## ------------------------------------------------------------------------------------
+## Gateway & Interface Endpoint Controls
+## ------------------------------------------------------------------------------------
+module "tower_interface_endpoint_sg" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  name        = "${local.global_prefix}_interface_sg"
+  description = "Allowed ingress on VPC endpoints in Tower Subnet."
+
+  vpc_id              = local.vpc_id
+  ingress_cidr_blocks = [var.vpc_new_cidr_range]
+  ingress_rules       = ["all-all"]
+  egress_rules        = var.sg_egress_interface_endpoint
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - All Security Group resources from 1.5.0 reintroduced in a deprecation section at bottom of `002_security_groups.tf`. This is to help existing sites transition to the new 1.6.0+ SG model.
                 - Commented out ingress rules for deprecated SG `tower_ec2_direct_connect_sg` due to `local.tower_ec2_direct_connect_sg_final` no longer existing.
                 - Commented out ingress rules for deprecated SG `tower_ec2_alb_connect_sg` due to `local.tower_ec2_alb_connect_sg_final` no longer existing.
+            - Modified `connection_strings` module `data.external.generate_db_connection_string` to use absolute path from module root rather than relative path.
         <br /><br />
         - Security
             - B

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - Patched issues reported in [234 - Release 1.6.0 deployment issues](https://github.com/seqeralabs/cx-field-tools-installer/issues/234)
         <br /><br />
         - Architecture
-            - S
+            - All Security Group resources from 1.5.0 reintroduced in a deprecation section at bottom of `002_security_groups.tf`. This is to help existing sites transition to the new 1.6.0+ SG model.
+                - Commented out ingress rules for deprecated SG `tower_ec2_direct_connect_sg` due to `local.tower_ec2_direct_connect_sg_final` no longer existing.
+                - Commented out ingress rules for deprecated SG `tower_ec2_alb_connect_sg` due to `local.tower_ec2_alb_connect_sg_final` no longer existing.
         <br /><br />
         - Security
             - B

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # CHANGELOG
-> Last updated: July 27, 2025
+> Last updated: Aug 18, 2025
 
 This file was created post 1.5.0 Release.
 
@@ -20,21 +20,16 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - All Security Group resources from 1.5.0 reintroduced in a deprecation section at bottom of `002_security_groups.tf`. This is to help existing sites transition to the new 1.6.0+ SG model.
                 - Commented out ingress rules for deprecated SG `tower_ec2_direct_connect_sg` due to `local.tower_ec2_direct_connect_sg_final` no longer existing.
                 - Commented out ingress rules for deprecated SG `tower_ec2_alb_connect_sg` due to `local.tower_ec2_alb_connect_sg_final` no longer existing.
-            - Modified `connection_strings` module `data.external.generate_db_connection_string` to use absolute path from module root rather than relative path.
-        <br /><br />
-        - Security
-            - B
+            - Modified `connection_strings` module:
+                - `data.external.generate_db_connection_string` to use absolute path from module root rather than relative path.
+                - Added `wave_lite_enabled` qualifier to variables associated with Wave Lite external DB and external Redis.
         <br /><br />
         - Documentation
             - Renamed _Changelog_ entry from `2.0.0` to `1.6.0`.
             - Added discrete _Upgrade Steps_ page.
             - Added warning re: EBS volume during multi-version upgrade cycle.
-        <br /><br />
-        - Validation
-            - 
-        <br /><br />
-        - Testing
-            - 
+            - Added escape hatch documentation is deployed resource doesn't reflect expected changes.
+
 
 ### Configuration File Changes
 #### `terraform.tfvars`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
     - **CX Installer**
         - General
             - Patched issues reported in [234 - Release 1.6.0 deployment issues](https://github.com/seqeralabs/cx-field-tools-installer/issues/234)
+            - Added explicit call-out in 1.6.0 section that new variable `use_mocks` was added.
         <br /><br />
         - Architecture
             - All Security Group resources from 1.5.0 reintroduced in a deprecation section at bottom of `002_security_groups.tf`. This is to help existing sites transition to the new 1.6.0+ SG model.
@@ -77,6 +78,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - Refactored `assets/src/customcerts/`: Generation script supports multiple domains & removed placeholder files.
             - Merged / broke out EC2 security groups for easier management and better permissions scoping. **This could break ancillary components if you reused the security groups elsewhere!**
             - Refactored when most `assets/target/` files are produced. Rather than waiting for all infrastructure to be created, we now create files as soon as minimal dependencies are met (_to facilitate testing_).
+            - Added new variable `use_mocks`to `variables.tf`. This value defaults to `false` since it should only be `true` during testing.
             - Added `... && !var.use_mock` to database and redis assets' `count` property to facilitate testing.
             - Moved conditional Ansible steps from Bash environment logic to `.tpl` inclusion / exclusion.
             - Modified `docker-compose.yml` so that all configuration files are mounted from their respective `target/**` folder.

--- a/documentation/upgrade_steps.md
+++ b/documentation/upgrade_steps.md
@@ -2,9 +2,31 @@
 Steps for existing implementations to follow when upgrading your current deployment to a new release (_current for Releases <= `1.6.1`_).
 
 
-## Expected Filesystem Deployment
+## Expected Filesystem Deployment (Example)
+
 ```bash
-TODO: ADD diagram while doing real-world fix test
+├── multideploy
+│   ├── 1-5-0
+│   │   ├── DONTDELETE
+│   │   ├── assets
+│   │   ├── documentation
+│   │   ├── scripts
+│   │   └── templates
+│   ├── 1-6-0
+│   │   ├── DONTDELETE
+│   │   ├── assets
+│   │   ├── documentation
+│   │   ├── modules
+│   │   ├── scratch
+│   │   ├── scripts
+│   │   ├── templates
+│   │   └── tests
+│   ├── 1-6-1
+│   │   ├── DONTDELETE
+│   │   ├── assets
+│   │   ├── modules
+│   │   └── scripts
+│   │   └── ...
 ```
 
 
@@ -32,4 +54,21 @@ If multiple jumps are needed to reach the most recent Seqera Platform release, y
 1. Run `terraform apply`.
 
 
+## Escape Hatch
+The solution should normally be able to conduct a full end-to-end upgrade without requiring intervention. Sometimes, however, Terraform assets can get "stuck" in a way that precludes this. For example:
 
+1. Modifying your deployment options in a such a way that a new Security Group needs to be added to the EC2, but the EC2 is not recreated so the new SG on the Launch Template fails to apply.
+
+1. A resource is removed from the project but still attached to a pre-existing asset and cannot be removed, thereby causing Terraform to throw an error (e.g. SG on EC2).
+
+In such cases, it is often best to delete the offending resource and redeploy (**WARNING: Be extra careful about deletions that can impact your database**). This can be done by:
+
+1. Deleting the offending resource from within the AWS console.
+
+1. Deleting via Terraform.
+
+    ```bash
+    terraform refresh
+    terraform state list                                    # (look for targeted resource)
+    terraform delete destroy -target=aws_instance.ec2       # (e.g. delete EC2)
+    ```

--- a/documentation/upgrade_steps.md
+++ b/documentation/upgrade_steps.md
@@ -27,6 +27,7 @@ If multiple jumps are needed to reach the most recent Seqera Platform release, y
 1. [Update your `~/.ssh/config`](../documentation/setup/prepare_openssh.md) to point to the new release folder.
 1. Update your `terraform.tfvars` & SSM secrets as per guidance in [CHANGELOG](../CHANGELOG.md#configuration-file-changes).
 1. [OPTIONAL] Re-implement any customizations you've added to your current deployment.
+1. Run `terraform init -upgrade` to register new modules.
 1. Run `terraform plan` and ensure no errors are thrown.
 1. Run `terraform apply`.
 

--- a/modules/connection_strings/v1.0.0/main.tf
+++ b/modules/connection_strings/v1.0.0/main.tf
@@ -98,24 +98,25 @@ locals {
   # WAVE-LITE
   # ---------------------------------------------------------------------------------------
   # TODO: June 16/25 -- Consider if `rediss://` hardcode aligns with how config is presented.
-  wave_enabled = (var.flag_use_wave || var.flag_use_wave_lite) && !var.flag_do_not_use_https ? true : false
+  wave_lite_enabled = var.flag_use_wave_lite && !var.flag_do_not_use_https ? true : false
+  wave_enabled      = var.flag_use_wave || local.wave_lite_enabled ? true : false
 
   tower_wave_dns = local.wave_enabled ? var.wave_server_url : "N/A"
   tower_wave_url = local.wave_enabled ? "https://${local.tower_wave_dns}" : "N/A"
 
   # NOTE: Current as of July 29/25, Wave-Lite cannot be deployed to a pre-existing RDS Postgres instance.
   wl_db_container     = var.flag_use_container_db || var.flag_use_existing_external_db ? "wave-db" : ""
-  wl_db_external_mock = var.flag_create_external_db && var.use_mocks ? "mock.wave-db.com" : ""
-  wl_db_external_new  = var.flag_create_external_db && !var.use_mocks ? var.rds_wave_lite.db_instance_address : ""
-  wave_lite_db_dns    = local.wave_enabled ? join("", [local.wl_db_container, local.wl_db_external_mock, local.wl_db_external_new]) : "N/A"
-  wave_lite_db_url    = local.wave_enabled ? "jdbc:postgresql://${local.wave_lite_db_dns}:5432/wave" : "N/A"
+  wl_db_external_mock = var.flag_create_external_db && local.wave_lite_enabled && var.use_mocks ? "mock.wave-db.com" : ""
+  wl_db_external_new  = var.flag_create_external_db && local.wave_lite_enabled && !var.use_mocks ? var.rds_wave_lite.db_instance_address : ""
+  wave_lite_db_dns    = local.wave_lite_enabled ? join("", [local.wl_db_container, local.wl_db_external_mock, local.wl_db_external_new]) : "N/A"
+  wave_lite_db_url    = local.wave_lite_enabled ? "jdbc:postgresql://${local.wave_lite_db_dns}:5432/wave" : "N/A"
 
   # NOTE: Current as of July 29/25, Wave-Lite container redis doesn't support SSL. Also can't use existing redis (not an option).
   wl_redis_container     = var.flag_use_container_redis ? "wave-redis" : ""
-  wl_redis_external_mock = var.flag_create_external_redis && var.use_mocks ? "mock.wave-redis.com" : ""
-  wl_redis_external_new  = var.flag_create_external_redis && !var.use_mocks ? var.elasticache_wave_lite.dns : ""
+  wl_redis_external_mock = var.flag_create_external_redis && local.wave_lite_enabled && var.use_mocks ? "mock.wave-redis.com" : ""
+  wl_redis_external_new  = var.flag_create_external_redis && local.wave_lite_enabled && !var.use_mocks ? var.elasticache_wave_lite.dns : ""
   wl_redis_prefixed      = var.flag_create_external_redis ? "rediss://${local.wave_lite_redis_dns}" : "redis://${local.wave_lite_redis_dns}"
-  wave_lite_redis_dns    = local.wave_enabled ? join("", [local.wl_redis_container, local.wl_redis_external_mock, local.wl_redis_external_new]) : "N/A"
-  wave_lite_redis_url    = local.wave_enabled ? "${local.wl_redis_prefixed}:6379" : "N/A"
+  wave_lite_redis_dns    = local.wave_lite_enabled ? join("", [local.wl_redis_container, local.wl_redis_external_mock, local.wl_redis_external_new]) : "N/A"
+  wave_lite_redis_url    = local.wave_lite_enabled ? "${local.wl_redis_prefixed}:6379" : "N/A"
 }
 

--- a/modules/connection_strings/v1.0.0/main.tf
+++ b/modules/connection_strings/v1.0.0/main.tf
@@ -1,6 +1,6 @@
 # https://medium.com/@leslie.alldridge/terraform-external-data-source-using-custom-python-script-with-example-cea5e618d83e
 data "external" "generate_db_connection_string" {
-  program = ["python3", "${path.module}/../../../scripts/installer/data_external/generate_db_connection_string.py"]
+  program = ["python3", "${abspath(path.root)}/scripts/installer/data_external/generate_db_connection_string.py"]
   query   = {}
 
   # Example how to use:


### PR DESCRIPTION
Continuation of [https://github.com/seqeralabs/cx-field-tools-installer/pull/236](https://github.com/seqeralabs/cx-field-tools-installer/pull/236)

Actioning remaining items in #234:

- [x] Fixed relative script invocation path.
- [x] Fixed null resource error in `module connection_strings` re: external DB and Redis.
- [x] Added back deleted security groups as deprecated resources (_to smooth implementation upgrades_).  