### PR TITLE
Gwright99/249 fix wave containers in dc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
     - **CX Installer**
         - General
             - Added [EC2 instance role option](https://docs.seqera.io/platform-enterprise/enterprise/advanced-topics/use-iam-role#configure-seqera)
+            - Changed `wave-db` container pin from `postgres:latest` to `postgres:17.6`. This is necessary to due to a change in how the [data directory is managed in postgres containers >= 18](https://hub.docker.com/_/postgres#pgdata).
         <br /><br />
         - Documentation
             - Updated instance role docs to reflect terraform deployment option.
@@ -21,6 +22,8 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
         <br /><br />
         - Testing
             - Added refactored local testing framework. Validates `tower.env` to ensure correct representation of the EC2 instance role option, `TOWER_ALLOW_INSTANCE_CREDENTIALS`, based on selection set in terraform.tfvars file.
+            - Added `labels.seqera` entry to each Wave-Lite container to facilatate positive testing (in support of [issue 249](https://github.com/seqeralabs/cx-field-tools-installer/issues/249)).
+            - Added `labels.seqera` entry to generic `reverseproxy` container to align with Wave-Lite changes.
 
 ### Configuration File Changes
 #### `terraform.tfvars`

--- a/assets/src/docker_compose/docker-compose.yml.tpl
+++ b/assets/src/docker_compose/docker-compose.yml.tpl
@@ -238,6 +238,8 @@ services:
   #   - docker-compose.yml in `/home/ec2-user/``
   #   - All custom cert files present / generated in `/home/ec2-user/customcerts``
   reverseproxy:
+    labels:
+      seqera: reverseproxy
     image: nginx:latest
     container_name: reverseproxy
     networks:
@@ -302,7 +304,7 @@ services:
   wave-db:
     labels:
       seqera: wave-db
-    image: postgres:latest
+    image: postgres:17.6
     platform: linux/amd64
     expose:
       - 5432:5432

--- a/assets/src/docker_compose/docker-compose.yml.tpl
+++ b/assets/src/docker_compose/docker-compose.yml.tpl
@@ -262,6 +262,8 @@ services:
 
 %{ if flag_use_wave_lite == true ~}
   wave-lite:
+    labels:
+      seqera: wave-lite
     image: hrma017/app:1.20.0-B1   # TODO: swap with real image later.
     # ports:
     #   - 9099:9090
@@ -284,6 +286,8 @@ services:
       replicas: ${num_wave_lite_replicas}
 
   wave-lite-reverse-proxy:
+    labels:
+      seqera: wave-lite-reverse-proxy
     image: nginx:latest
     ports:
       - "9099:80"
@@ -293,10 +297,11 @@ services:
       - wave-lite
     networks:
       - backend
-%{ endif ~}
 
 %{ if wave_lite_db_container == true ~}
   wave-db:
+    labels:
+      seqera: wave-db
     image: postgres:latest
     platform: linux/amd64
     expose:
@@ -316,6 +321,8 @@ services:
 
 %{ if wave_lite_redis_container == true ~}
   wave-redis:
+    labels:
+      seqera: wave-redis
     image: cr.seqera.io/public/redis:7.0.10
     platform: linux/amd64
     expose:
@@ -326,6 +333,7 @@ services:
       - $HOME/.wave/db/wave-lite-redis:/data
     networks:
       - backend
+%{ endif ~}
 %{ endif ~}
 
 

--- a/tests/datafiles/expected_results/expected_results.py
+++ b/tests/datafiles/expected_results/expected_results.py
@@ -169,7 +169,12 @@ def generate_tower_sql_entries_all_active(overrides={}):
 def generate_docker_compose_yml_entries_all_active(overrides={}):
     # I know it's a bit dumb to have kv pairs here since we only care about keys buuut ... it helps consistency.
     baseline = {
-        "present": {},
+        "present": {
+            "services.wave-lite.labels.seqera"                  : 'wave-lite',
+            "services.wave-lite-reverse-proxy.labels.seqera"    : 'wave-lite-reverse-proxy',
+            "services.wave-db.labels.seqera"                    : 'wave-db',
+            "services.wave-redis.labels.seqera"                 : 'wave-redis',
+        },
         "omitted": {
             "services.reverseproxy"  : 'reverseproxy'
         }
@@ -443,7 +448,11 @@ def generate_docker_compose_yml_entries_all_disabled(overrides={}):
     baseline = {
         "present": {},
         "omitted": {
-            "services.reverseproxy"  : '',
+            "services.reverseproxy"             : '',
+            "services.wave-lite"                : '',
+            "services.wave-lite-reverse-proxy"  : '',
+            "services.wave-db"                  : '',
+            "services.wave-redis"               : '',
         }
     }
     baseline = purge_baseline_of_specified_overrides(baseline, overrides)

--- a/tests/datafiles/expected_results/expected_results.py
+++ b/tests/datafiles/expected_results/expected_results.py
@@ -176,7 +176,7 @@ def generate_docker_compose_yml_entries_all_active(overrides={}):
             "services.wave-redis.labels.seqera"                 : 'wave-redis',
         },
         "omitted": {
-            "services.reverseproxy"  : 'reverseproxy'
+            "services.reverseproxy"  : ''
         }
     }
     baseline = purge_baseline_of_specified_overrides(baseline, overrides)

--- a/tests/unit/config_files/test_config_file_content.py
+++ b/tests/unit/config_files/test_config_file_content.py
@@ -85,7 +85,7 @@ def test_private_ca_reverse_proxy_active(session_setup):
 
     assertion_modifiers["docker_compose"] = {
         "present": {
-            "services.reverseproxy.container_name" : 'reverseproxy'
+            "services.reverseproxy.labels.seqera" : 'reverseproxy'
         },
         "omitted": {}
     }

--- a/tests/unit/config_files/test_config_file_content.py
+++ b/tests/unit/config_files/test_config_file_content.py
@@ -89,8 +89,8 @@ def test_private_ca_reverse_proxy_active(session_setup):
         },
         "omitted": {}
     }
+    
     tc_assertions       = generate_assertions_all_active(tc_files, assertion_modifiers)
-
     verify_all_assertions(tc_files, tc_assertions)
 
 
@@ -155,7 +155,7 @@ def test_new_db_all_enabled(session_setup):
     """
     plan                = prepare_plan(tf_modifiers)
 
-    desired_files       = ["tower_env", "groundswell_env", "wave_lite_yml"]
+    desired_files       = ["tower_env", "groundswell_env", "wave_lite_yml", "docker_compose"]
     assertion_modifiers = assertion_modifiers_template()
     tc_files            = generate_tc_files(plan, desired_files, sys._getframe().f_code.co_name)
 
@@ -179,8 +179,19 @@ def test_new_db_all_enabled(session_setup):
         },
         "omitted": {}
     }
-    tc_assertions       = generate_assertions_all_active(tc_files, assertion_modifiers)
 
+    assertion_modifiers["docker_compose"] = {
+        "present": {
+            "services.wave-lite.labels.seqera"                  : 'wave-lite',
+            "services.wave-lite-reverse-proxy.labels.seqera"    : 'wave-lite-reverse-proxy',
+            "services.wave-redis.labels.seqera"                 : 'wave-redis',
+        },
+        "omitted": {
+            "services.wave-db"                  : '',
+        }
+    }
+
+    tc_assertions       = generate_assertions_all_active(tc_files, assertion_modifiers)
     verify_all_assertions(tc_files, tc_assertions)
 
 
@@ -364,7 +375,7 @@ def test_new_redis_all_enabled(session_setup):
     """
     plan                = prepare_plan(tf_modifiers)
 
-    desired_files       = ["tower_env", "data_studios_env", "wave_lite_yml"]
+    desired_files       = ["tower_env", "data_studios_env", "wave_lite_yml", "docker_compose"]
     assertion_modifiers = assertion_modifiers_template()
     tc_files            = generate_tc_files(plan, desired_files, sys._getframe().f_code.co_name)
 
@@ -388,8 +399,19 @@ def test_new_redis_all_enabled(session_setup):
         },
         "omitted": {}
     }
-    tc_assertions       = generate_assertions_all_active(tc_files, assertion_modifiers)
 
+    assertion_modifiers["docker_compose"] = {
+        "present": {
+            "services.wave-lite.labels.seqera"                  : 'wave-lite',
+            "services.wave-lite-reverse-proxy.labels.seqera"    : 'wave-lite-reverse-proxy',
+            "services.wave-db.labels.seqera"                    : 'wave-db',
+        },
+        "omitted": {
+            "services.wave-redis"               : '',
+        }
+    }
+
+    tc_assertions       = generate_assertions_all_active(tc_files, assertion_modifiers)
     verify_all_assertions(tc_files, tc_assertions)
 
 


### PR DESCRIPTION
Fixed problem where `wave-db` and `wave-redis` were showing up in docker-compose file even if wave-lite hadn't been activated.

Fixed:
- docker-compose logic itself
- testing framework to cover this scenario (when containers should be present / not present).
- Pinned `wave-db` to `postgres:17.6` as a secondary problem found during testing.