### PR TITLE
Add configuration to control auto-assignment of public IPv4

### DIFF
--- a/000_main.tf
+++ b/000_main.tf
@@ -68,6 +68,7 @@ locals {
   vpc_id                      = var.flag_create_new_vpc == true ? module.vpc[0].vpc_id : var.vpc_existing_id
   vpc_private_route_table_ids = var.flag_create_new_vpc == true ? module.vpc[0].private_route_table_ids : data.aws_route_tables.preexisting[0].ids
 
+  flag_map_public_ip_on_launch = var.flag_map_public_ip_on_launch == true || var.flag_make_instance_public == true ? true : false
 
   # SSM
   # ---------------------------------------------------------------------------------------

--- a/001_vpc.tf
+++ b/001_vpc.tf
@@ -15,7 +15,7 @@ module "vpc" {
   public_subnets  = var.vpc_new_public_subnets
   # database_subnets        = var.vpc_new_db_subnets
 
-  map_public_ip_on_launch                           = var.flag_make_instance_public == true ? true : false
+  map_public_ip_on_launch                           = local.flag_map_public_ip_on_launch
   public_subnet_private_dns_hostname_type_on_launch = "ip-name"
 
   # Opinionated for simplicity.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - Changed `wave-db` container pin from `postgres:latest` to `postgres:17.6`. This is necessary to due to a change in how the [data directory is managed in postgres containers >= 18](https://hub.docker.com/_/postgres#pgdata). [`#250`](https://github.com/seqeralabs/cx-field-tools-installer/issues/250)
             - Updated redis to `7.2.6` for Platform and Wave. [`#251`](https://github.com/seqeralabs/cx-field-tools-installer/issues/251)
             - Added warning and check for personal workspace disablement. [`#246`](https://github.com/seqeralabs/cx-field-tools-installer/issues/246)
+            - Added setting to auto-assign IPv4 addresses to instances in public subnets.
         <br /><br />
+
         - Documentation
             - Updated instance role docs to reflect terraform deployment option. [`#242`](https://github.com/seqeralabs/cx-field-tools-installer/issues/242)
             - Updated templated `terraform.tfvars` with instance role flag and related considerations. [`#242`](https://github.com/seqeralabs/cx-field-tools-installer/issues/242)
         <br /><br />
+
         - Testing
             - Added refactored local testing framework. Validates `tower.env` to ensure correct representation of the EC2 instance role option, `TOWER_ALLOW_INSTANCE_CREDENTIALS`, based on selection set in terraform.tfvars file. [`#242`](https://github.com/seqeralabs/cx-field-tools-installer/issues/242)
             - Added `labels.seqera` entry to each Wave-Lite container to facilatate positive testing (in support of [`#249`](https://github.com/seqeralabs/cx-field-tools-installer/issues/249)).
@@ -33,6 +36,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
 | Status | Component | Parameter Name | Description |
 | ------ | --------- | -------------- | ----------- |
 | New | Platform & Seqerakit | `flag_allow_aws_instance_credentials` | Allows activation of EC2 Instance Role for Seqera Platform to use when authenticating to AWS. |
+| New | Platform | `flag_map_public_ip_on_launch` | Configure VPC module to enable auto-assignment of IPv4 addresses to instances spun up in public subnets. |
 
 
 

--- a/templates/TEMPLATE_terraform.tfvars
+++ b/templates/TEMPLATE_terraform.tfvars
@@ -302,12 +302,18 @@ vpc_new_batch_subnets = ["10.0.3.0/24"]
 vpc_new_db_subnets    = ["10.0.3.0/24", "10.0.4.0/24"]
 vpc_new_redis_subnets = ["10.0.5.0/24"]
 
-
 # Must be >= 2, in different AZs. Ensure only public subnets (nothing needs to be in these).
 vpc_new_alb_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
 
 # Specify is VPC flow logs should be enabled or not. Have cost implication.
 enable_vpc_flow_logs = false
+
+# Control whether a public IPv4 address should be assigned to instances spun up in the VPC subnets.
+# There is an hourly cost for each IP, so this is default to false. However, if you place AWS Batch 
+# instances in a public subnet and dont assign a public IP, those machines will fail due join the ECS
+# cluster due to a failure to downloaded assets from the public internet during boot. 
+# WARNING: If you enable this, consider making your ingress CIDR ranges more restrictive.
+flag_map_public_ip_on_launch = false
 
 
 /*

--- a/variables.tf
+++ b/variables.tf
@@ -156,6 +156,10 @@ variable "vpc_new_redis_subnets" { type = list(string) }
 variable "vpc_new_alb_subnets" { type = list(string) }
 
 variable "enable_vpc_flow_logs" { type = bool }
+variable "flag_map_public_ip_on_launch" { 
+  type = bool
+  default = false
+}
 
 
 # ------------------------------------------------------------------------------------


### PR DESCRIPTION
Implements #216.

While it is expected that most deployments will not need this feature (hence default to 'false'), I test often enough with an AWS Batch CE which leverages the same VPC as deployed by the Installer. When I choose to use a public subnet, it always takes me a few minutes to realize that I've neglected to assign the IP, thus causing steps in the instance Launch Template (e.g. download Cloudwatch Agent config) to fail because the HTTP traffic can't get back. Once this is realized the current instance must be terminated and a new one spun up. This wastes time, money, and is annoying.