### PR TITLE
fix: added support for openapi

### DIFF
--- a/009_define_file_templates.tf
+++ b/009_define_file_templates.tf
@@ -49,6 +49,7 @@ locals {
       flag_studio_enable_path_routing = var.flag_studio_enable_path_routing,
 
       flag_allow_aws_instance_credentials = var.flag_allow_aws_instance_credentials,
+      tower_enable_openapi = var.tower_enable_openapi
     }
   )
 

--- a/assets/src/tower_config/tower.env.tpl
+++ b/assets/src/tower_config/tower.env.tpl
@@ -72,6 +72,15 @@ TOWER_ENABLE_UNSAFE_MODE=true
 TOWER_ENABLE_UNSAFE_MODE=false
 %{ endif ~}
 
+# ------------------------------------------------
+# ENABLE OpenAPI  
+# Set this variable to enable the OpenAPI documentation endpoint
+# ------------------------------------------------
+%{ if tower_enable_openapi == true }
+TOWER_ENABLE_OPENAPI=true
+%{ else ~}
+TOWER_ENABLE_OPENAPI=false
+%{ endif ~}
 
 # ------------------------------------------------
 # Wave & Fusion v2

--- a/templates/TEMPLATE_terraform.tfvars
+++ b/templates/TEMPLATE_terraform.tfvars
@@ -750,6 +750,8 @@ tower_email_trusted_users = "REPLACE_ME"
 
 tower_audit_retention_days = 1095 # 3 years (value in days)
 
+tower_enable_openapi = true
+
 
 /*
 ## ------------------------------------------------------------------------------------

--- a/variables.tf
+++ b/variables.tf
@@ -392,6 +392,7 @@ variable "tower_email_trusted_users" { type = string }
 
 variable "tower_audit_retention_days" { type = number }
 
+variable "tower_enable_openapi" { type = bool }
 
 # ------------------------------------------------------------------------------------
 # TOWER CONFIGURATION - OIDC


### PR DESCRIPTION
This PR adds support for enabling OpenAPI in Tower by introducing the `tower_enable_openapi` variable into terraform.tfvars which maps to the Platform configuration TOWER_ENABLE_OPENAPI. This allows OpenAPI to be toggled on or off through Terraform-managed configuration instead of requiring manual environment changes.