### PR TITLE
fix: added extra configuration snippet to handle change introduced by…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - Added setting to auto-assign IPv4 addresses to instances in public subnets.
             - Modified docker compose file to use official Seqera Wave image & made image tag configurable. [`#252`](https://github.com/seqeralabs/cx-field-tools-installer/issues/252)
             - Made OpenAPI support configurable.
+            - Added Entra ID (aka Azure AD) OAUTH2 configuration snippet in `tower.yml.tpl` for Platform versions < 25.3. [`#267`](https://github.com/seqeralabs/cx-field-tools-installer/issues/267)
         <br /><br />
 
         - Documentation

--- a/assets/src/tower_config/tower.yml.tpl
+++ b/assets/src/tower_config/tower.yml.tpl
@@ -42,6 +42,16 @@ micronaut:
       read-timeout: 30s
 
   security:
+    # oauth2:
+    #   clients:
+    #     oidc:
+    #       openid:
+    #         token:
+    #           # See: https://github.com/seqeralabs/cx-field-tools-installer/issues/267
+    #           # Commented out by default since snippet added in CX Installer release which uses Platform 25.3 by default.
+    #           # This fix MUST be present for any Seqera Platform version < 25.3
+    #           auth-method: "client_secret_post"
+
     redirect:
       login-success : "/auth?success=true"
       login-failure : "/auth?success=false"


### PR DESCRIPTION
… Entra ID OIDC

See: https://github.com/seqeralabs/cx-field-tools-installer/issues/267 
Snippet must be used by any deployment of Seqera Platform < 25.3 which uses Entra ID as its OIDC IDP.