### PR TITLE
chore: bump Platform to v25.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
                 - Added verification check and warning. [`#276`](https://github.com/seqeralabs/cx-field-tools-installer/issues/276)
             - Removed `FLYWAY_LOCATIONS` as configurable option.
             - Updated Groundswell container version from 0.4.3 to 0.4.6.
+            - Updated Seqera Platform container version from v25.2.2 to v25.3.0.
         <br /><br />
 
         - Documentation
@@ -47,6 +48,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
 | New | Platform | `tower_enable_openapi` | Control whether your Platform instance enables the OpenAPI console or not. |
 | New | Wave | `wave_lite_container_version` | Specify the exact Wave image to be deployed for the Wave-Lite service. |
 ||||
+| Modified | Platform | `tower_container_version` | Updated from v25.2.2 to v25.3.0 |
 | Modified | Groundswell | `swell_container_version` | Updated  from 0.4.3 to 0.4.6 |
 ||||
 | Deleted | Platform | `flyway_locations` | Classpath configuration. Not necessary in modern deployments. |

--- a/templates/TEMPLATE_terraform.tfvars
+++ b/templates/TEMPLATE_terraform.tfvars
@@ -39,7 +39,7 @@ aws_account = "REPLACE_ME"
 aws_region  = "REPLACE_ME"
 aws_profile = "REPLACE_ME"
 
-tower_container_version = "v25.2.2"
+tower_container_version = "v25.3.0"
 
 
 /*

--- a/tests/datafiles/generate_core_data.sh
+++ b/tests/datafiles/generate_core_data.sh
@@ -44,7 +44,7 @@ aws_account = "128997144437"
 aws_region  = "us-east-1"
 aws_profile = "development"
 
-tower_container_version                 = "v25.2.0"
+tower_container_version                 = "v25.3.0"
 
 
 ## ------------------------------------------------------------------------------------


### PR DESCRIPTION
See: https://github.com/seqeralabs/cx-field-tools-installer/issues/264

Change affects container version only. Related configuration (if any) will be added in a separate PR when sorted out with Seqera Product / Docs.