### PR TITLE
Gwright99/fail tests if original tfvars missing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,6 +88,28 @@ def session_setup():
     AWS preflight is deliberately NOT part of this fixture — tests that need real AWS
     consume the separate `aws_preflight` fixture instead. See issue #351.
     """
+    # Preflight: terraform.tfvars must exist in project root before we start.
+    # session_setup backs up the deployer's real tfvars at session start and restores it
+    # on teardown — without that file as the starting point, `FileHelper.move_file` raises,
+    # session_setup partially completes, and downstream tests that depend on project-root
+    # state files (e.g. `prepare_plan`-based variable_validation tests) fail with confusing
+    # FileNotFoundError chains on entirely different files. Fail fast with an actionable
+    # error instead.
+    if not os.path.exists(FP.TFVARS_BASE):
+        backup_exists = os.path.exists(FP.TFVARS_BACKUP)
+        recovery_hint = (
+            f"A backup exists at `{FP.TFVARS_BACKUP}` (likely from a previous test run that crashed "
+            f"mid-teardown). Restore it manually: `mv {FP.TFVARS_BACKUP} {FP.TFVARS_BASE}`."
+            if backup_exists
+            else f"Copy `templates/TEMPLATE_terraform.tfvars` to `{FP.TFVARS_BASE}` and configure it for your deployment."
+        )
+        pytest.exit(
+            f"Precondition failed: `terraform.tfvars` not found at `{FP.TFVARS_BASE}`. "
+            f"The testing framework backs up this file at session start and restores it on teardown; "
+            f"without it, test execution cannot proceed.\n\nTo fix: {recovery_hint}",
+            returncode=2,
+        )
+
     # Create a fresh copy of the base testing terraform.tfvars file.
     subprocess.run("make generate_test_data", shell=True, check=True)  # noqa: S602, S607  (intentional shell command; relies on PATH; standard for test env)
 


### PR DESCRIPTION
## Summary

Minor change to testing harness. Fail immediately if `terraform.tfvars` not present in base repo (this is backed up to not delete real-world settings). I could probably refactor this section of logic more to completely decouple but cant justify the redesign/rework time.

## Related Issues

#378 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore
- [ ] Documentation
- [x] Tests

## Changes

- Made sessions fixture fail if expected `terraform.tfvars` file isnt present.

## Test Plan

<!-- How was this validated? Check all that apply and add details. -->

- [ ] `make verify` passes
- [ ] `make plan` reviewed
- [x] `./tests/run_tests_all.sh` passes
- [ ] Unit tests added/updated
- [ ] Integration tested against a live deployment
- [ ] `ruff` run on modified Python files

## Configuration / Migration Notes

n/a

## Screenshots / Output

n/a

## Checklist

- [ ] Updated `templates/TEMPLATE_terraform.tfvars` if variables changed
- [ ] Updated CHANGELOG / VERSION if applicable
- [ ] No secrets committed; sensitive values use SSM Parameter Store
- [ ] Documentation updated (README, CLAUDE.md, inline docs)
