### PR TITLE
Gwright99/fix sushmas fix

### DIFF
--- a/templates/TEMPLATE_terraform.tfvars
+++ b/templates/TEMPLATE_terraform.tfvars
@@ -457,12 +457,8 @@ data_studio_path_routing_url    = "REPLACE_ME_IF_NECESSARY"
 # See Design Decisions #20 and #21 in documentation/design_decisions.md for the full list and rationale.
 
 # Studios - General behaviour (v26.1.0+)
-data_studio_default_lifespan           = "8"   # default lifespan in hours per Studio
-flag_studio_private_by_default         = false # make Studios private by default
-data_studio_iframe_eligible_workspaces = ""    # comma-separated workspace IDs; empty = all
-
-# Studios - SSH (v26.1.0+)
-tower_ssh_keys_supported_types = "ssh-rsa,ssh-ed25519,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521" # accepted SSH public key types
+data_studio_default_lifespan   = "8"   # default lifespan in hours per Studio
+flag_studio_private_by_default = false # make Studios private by default
 
 # Studios - Metrics (v26.1.0+)
 data_studio_metrics_eligible_workspaces = "" # comma-separated workspace IDs; empty = all


### PR DESCRIPTION
## Summary

Commit [08544d8](https://github.com/seqeralabs/cx-field-tools-installer/commit/08544d85f5d37b16cbb4d7db92876029a985116c) was pushed directly to the feature branch without a PR. The commit contained a change which was not fully implemented, with the missing part breaking a portion of the test suite. 

This PR implements the missing change and makes the test suite run green again.

## Related Issues

#378 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## Changes

- Removed `data_studio_iframe_eligible_workspaces` and `tower_ssh_keys_supported_types` from `templates/TEMPLATE_terrraform.tfvars`.

## Test Plan

- [ ] `make verify` passes
- [ ] `make plan` reviewed
- [x] `./tests/run_tests_all.sh` passes
- [ ] Unit tests added/updated
- [ ] Integration tested against a live deployment
- [ ] `ruff` run on modified Python files

## Configuration / Migration Notes

n/a

## Screenshots / Output

n/a

## Checklist

- [x] Updated `templates/TEMPLATE_terraform.tfvars` if variables changed
- [ ] Updated CHANGELOG / VERSION if applicable
- [ ] No secrets committed; sensitive values use SSM Parameter Store
- [ ] Documentation updated (README, CLAUDE.md, inline docs)
