### PR TITLE
chore: added logger config to suppress HS256/RS256 stack traces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
 ## 1.8.1 (June 2026)
 
 - **Notable Changes**
+    - **CX Installer**
+        - General
+            - Added logger config in `tower.yml` to disable noisy (but benign) JWT validation stack traces.
 
     - Documentation
         - Fixed `pipeline_versioning_eligible_workspaces` default value in `TEMPLATE_terraform.tfvars` from `null` to `""`. [`#401`](https://github.com/seqeralabs/cx-field-tools-installer/issues/401)

--- a/assets/src/tower_config/tower.yml.tpl
+++ b/assets/src/tower_config/tower.yml.tpl
@@ -15,6 +15,9 @@ logger:
     io.micronaut.security: DEBUG
     io.seqera.tower: DEBUG
     io.seqera.tower.security.oidc: DEBUG
+    # See https://github.com/seqeralabs/cx-field-tools-installer/issues/403
+    # Suppresses very noisy (but benign) stack traces in backend when Studios active.
+    io.micronaut.security.token.jwt.nimbus.NimbusReactiveSignatureConfigurationAdapter: 'OFF'
 
 
 mail:


### PR DESCRIPTION
## Summary

Implements #403 

## Related Issues

#403 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor / chore
- [ ] Documentation
- [ ] Tests

## Changes

- Disables logging out of `NimbusReactiveSignatureConfigurationAdapter` class. See issue for full details.

## Test Plan

- [ ] `make verify` passes
- [ ] `make plan` reviewed
- [ ] `./tests/run_tests_all.sh` passes
- [ ] Unit tests added/updated
- [x] Integration tested against a live deployment
- [ ] `ruff` run on modified Python files

## Configuration / Migration Notes

- Will need to be added to `1.8.1` patch.

## Screenshots / Output

n/a

## Checklist

- [ ] Updated `templates/TEMPLATE_terraform.tfvars` if variables changed
- [x] Updated CHANGELOG / VERSION if applicable
- [ ] No secrets committed; sensitive values use SSM Parameter Store
- [ ] Documentation updated (README, CLAUDE.md, inline docs)
