### PR TITLE
fix: added security groups directly to ec2 resource definition

### DIFF
--- a/006_ec2.tf
+++ b/006_ec2.tf
@@ -104,6 +104,14 @@ resource "aws_instance" "ec2" {
 
   subnet_id = module.subnet_collector.subnet_ids_ec2[0]
 
+  # Attach SGs directly to the instance, not only via the launch template.
+  # Launch-template SG changes do not propagate to running instances (LT is creation-time
+  # only, and `version = "$Latest"` is a literal string that produces no Terraform diff),
+  # so toggling SG-gating flags post-deploy was silently a no-op on the live ENI. Setting
+  # `vpc_security_group_ids` here lets the provider call ModifyInstanceAttribute on drift.
+  # See #404.
+  vpc_security_group_ids = local.sg_ec2_final
+
   launch_template {
     # id      = aws_launch_template.lt.id
     id = (var.ec2_update_ami_if_available == true ?
@@ -122,8 +130,16 @@ resource "aws_instance" "ec2" {
   # when it actually hasn't (triggered by `depends_on` or `data` read). See:
   #  - https://github.com/hashicorp/terraform-provider-aws/issues/5011
   #  - https://github.com/hashicorp/terraform/issues/11806
+  #
+  # `launch_template[0].version` is ignored for a different reason: in this provider
+  # version (~> 5.12.0), `launch_template.version` is ForceNew. When the LT is bumped
+  # (e.g., a new SG is added to its `vpc_security_group_ids`), the provider resolves the
+  # `"$Latest"` sentinel and surfaces the v_n -> v_(n+1) drift as a forced replacement of
+  # the running instance. Since SGs are now attached directly via `vpc_security_group_ids`
+  # above (no longer only via the LT), the LT version drift is harmless and the
+  # replacement is undesirable. Suppressing the diff keeps SG updates in-place. See #404.
   lifecycle {
-    ignore_changes = [user_data]
+    ignore_changes = [user_data, launch_template[0].version]
   }
 
   metadata_options {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
     - **CX Installer**
         - General
             - Added logger config in `tower.yml` to disable noisy (but benign) JWT validation stack traces.
+            - Security groups now attach to the EC2 instance directly, not only via the launch template — toggling SG-gating flags (e.g., `flag_enable_data_studio_ssh`) after the initial deploy now propagates to running instances on the next `terraform apply`. Affected sites will see a one-time in-place SG attachment update with no instance replacement. [`#404`](https://github.com/seqeralabs/cx-field-tools-installer/issues/404)
 
     - Documentation
         - Fixed `pipeline_versioning_eligible_workspaces` default value in `TEMPLATE_terraform.tfvars` from `null` to `""`. [`#401`](https://github.com/seqeralabs/cx-field-tools-installer/issues/401)


### PR DESCRIPTION
## Summary

Fixes failure to add/remove security groups from an already-deployed EC2 instance (because SGs are defined on a Launch Template which is itself frozen in time). 

## Related Issues

- #404 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## Changes

- Original solution attached security groups to the Launch Template that defined EC2 details.
- It was discovered that n+1 changes which required added/removing a security group on the EC2 would not occured. This was ultimately due to the "frozen" nature of the LT.
- Fix was to defined reconciled security groups directly onto the EC2.
- To maintain compatility with other solution mechanisms, SGs also defined on LT, but we now ignore LT changes and attach the new SG group directly to EC2.

## Test Plan

TODO

- [ ] `make verify` passes
- [ ] `make plan` reviewed
- [ ] `./tests/run_tests_all.sh` passes
- [ ] Unit tests added/updated
- [ ] Integration tested against a live deployment
- [ ] `ruff` run on modified Python files

## Configuration / Migration Notes

TODO: EC2 may need to be recreated once which could impact container DB/Redis

## Screenshots / Output

<!-- Optional: terraform plan snippets, logs, or screenshots. -->

## Checklist

- [ ] Updated `templates/TEMPLATE_terraform.tfvars` if variables changed
- [ ] Updated CHANGELOG / VERSION if applicable
- [ ] No secrets committed; sensitive values use SSM Parameter Store
- [ ] Documentation updated (README, CLAUDE.md, inline docs)
