### PR TITLE
feat: added SSH ControlMaster for faster SSH deployments.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ tests/.scenario_cache/
 
 .github/issue-drafts
 .github/pr-drafts
+
+.ssh-control

--- a/009_define_file_templates.tf
+++ b/009_define_file_templates.tf
@@ -396,6 +396,8 @@ locals {
 
       app_name = var.app_name,
       profile  = var.aws_profile,
+
+      ssh_control_path = "${path.module}/.ssh-control",
     }
   )
 

--- a/011_configure_vm.tf
+++ b/011_configure_vm.tf
@@ -20,8 +20,11 @@ resource "null_resource" "ssh_connectivity_check" {
     quiet       = true
     command     = <<-EOT
       set -e
+
+      echo "[$(date)] Ensuring .ssh-control folder exists."
+      mkdir -p ${path.module}/.ssh-control && chmod 700 ${path.module}/.ssh-control
+
       echo "[$(date)] Starting SSH connectivity check for ${var.app_name}"
-      
       counter=0
       until ssh -T ${var.app_name} || [ $counter -gt 60 ]; do
         echo "[$(date)] Waiting for SSH connection to be available."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,35 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
 ```
 
 
-## 1.8.1 (June 2026)
+## 1.9.0 (TBD)
+
+- **Notable Changes**
+    - **CX Installer**
+        - General
+            - Enabled SSH `ControlMaster` multiplexing in the rendered SSH config so the 10 `null_resource` provisioners share a single tunnel instead of opening a fresh one each. Roughly halves `terraform apply` wall-clock on private (EICE-tunneled) deployments. Sockets live at `~/.ssh/cm-%C` with a 10-minute persist timeout.
+            - `ec2-user` is now added to the `docker` group at instance launch via `launch_template_ec2.tpl` (cloud-init), before any SSH session opens. Avoids the staleness interaction between `ControlMaster` and mid-apply group membership changes that surfaced as `permission denied … /var/run/docker.sock`. **Existing sites: this is a fresh-deploy fix only.** Running EC2s will not pick up the new user_data without instance replacement (`terraform taint aws_instance.ec2 && terraform apply`); AMI pin is preserved across the replace. In-place workaround: `sudo usermod -aG docker ec2-user` on the host, then `ssh -O exit <host>; rm -f ~/.ssh/cm-*` locally.
+        <br /><br />
+
+        - Security
+            - TBD
+        <br /><br />
+
+        - Documentation
+            - TBD
+        <br /><br />
+
+        - Testing
+            - TBD
+
+
+### Configuration File Changes
+#### `terraform.tfvars`
+| Status | Component | Parameter Name | Description |
+| ------ | --------- | -------------- | ----------- |
+| TBD |  |  |  |
+
+
+## 1.8.1 (July 2026)
 
 - **Notable Changes**
     - **CX Installer**

--- a/assets/src/ansible/01_load_system_packages.yml
+++ b/assets/src/ansible/01_load_system_packages.yml
@@ -132,19 +132,6 @@
         daemon_reload: true
         enabled: true
 
-    - name: Sudoless Docker - Create Group
-      # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/group_module.html
-      ansible.builtin.group:
-        name: docker
-        state: present
-
-    - name: Sudoless Docker - Add ec2-user to docker
-      # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html
-      ansible.builtin.user:
-        name: ec2-user
-        groups: docker
-        append: yes
-
     - name: Install Java Corretto 17
       # tw relies on Java Corretto
       ansible.builtin.yum:

--- a/assets/src/ansible/02_update_file_configurations.yml.tpl
+++ b/assets/src/ansible/02_update_file_configurations.yml.tpl
@@ -19,13 +19,6 @@
         # Chown files
         chown -R ec2-user:ec2-user $HOME/target
 
-    - name: Switch primary group to docker to avoid need to logout.
-      # https://stackoverflow.com/questions/49434650/how-to-add-a-user-to-a-group-without-logout-login-bash-script
-      become: true
-      become_user: ec2-user
-      ansible.builtin.shell: |
-        newgrp docker
-
     - name: Reinstall Ansible community docker package
       become: true
       become_user: ec2-user

--- a/assets/src/aws/launch_template_ec2.tpl
+++ b/assets/src/aws/launch_template_ec2.tpl
@@ -12,8 +12,15 @@ write_files:
     content: |
       #!/usr/bin/env bash
       set -euo pipefail
-      
+
       exec > >(tee /var/log/tower-forge.log|logger -t TowerForge -s 2>/dev/console) 2>&1
+
+      # Pre-create docker group and add ec2-user before anything else so that
+      # any SSH session — including the ControlMaster opened by Terraform's
+      # provisioners — inherits the docker group at auth time. Docker (installed
+      # later by Ansible) reuses the existing group. See issue #XYZ.
+      groupadd -f docker
+      usermod -aG docker ec2-user
 
       ## Install packages
       yum update -y

--- a/assets/src/ssh/ssh_config.tpl
+++ b/assets/src/ssh/ssh_config.tpl
@@ -6,6 +6,10 @@ Host ${app_name}
     StrictHostKeyChecking no
     # Explicit mitigation for CVE-2025-26465. See: https://github.com/seqeralabs/cx-field-tools-installer/issues/180
     VerifyHostKeyDNS no
+    # Multiplex over a single master tunnel — subsequent ssh/scp invocations skip the SSH/EICE handshake.
+    ControlMaster auto
+    ControlPath ${ssh_control_path}/cm-%C
+    ControlPersist 10m
 %{~ else ~}
 Host ${app_name}
     Hostname ${node_id}
@@ -15,4 +19,8 @@ Host ${app_name}
     StrictHostKeyChecking no
     # Explicit mitigation for CVE-2025-26465. See: https://github.com/seqeralabs/cx-field-tools-installer/issues/180
     VerifyHostKeyDNS no
+    # Multiplex over a single master tunnel — subsequent ssh/scp invocations skip the SSH/EICE handshake.
+    ControlMaster auto
+    ControlPath ${ssh_control_path}/cm-%C
+    ControlPersist 10m
 %{ endif }


### PR DESCRIPTION
## Summary

- Establishes a master SSH connection that can be quickly reused by subsequent operations. This halves the time required for the existing `null_resource` assets using SSH to interact with the remote EC2, to complete their operations.
- Modifies EC2 launch template to assign `ec2-user` to `docker` group at boot rather than via Ansible run-time execution.
- Removes `ec2-user` / `docker` group logic from Ansible scripts.
- **WARNING: This changes the connection pattern and may impact existing sites. Test with additional caution. **

## Related Issues

- Implements #407 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## Changes

- Adds `.ssh-control/` folder in project root.
- Modifies `ssh-config` file to use `ControlMaster` mechanism.
- Modifies EC2 Launch Template and Ansible script re: how `ec2-user` gains `sudo`-less rights to `docker`.

## Test Plan

TODO

- [ ] `make verify` passes
- [ ] `make plan` reviewed
- [ ] `./tests/run_tests_all.sh` passes
- [ ] Unit tests added/updated
- [ ] Integration tested against a live deployment
- [ ] `ruff` run on modified Python files

## Configuration / Migration Notes

TODO -- existing EC2s likely do not need to be tainted, but must confirm.

## Screenshots / Output

n/a

## Checklist

- [ ] Updated `templates/TEMPLATE_terraform.tfvars` if variables changed
- [x] Updated CHANGELOG / VERSION if applicable
- [ ] No secrets committed; sensitive values use SSM Parameter Store
- [ ] Documentation updated (README, CLAUDE.md, inline docs)
