### PR TITLE
Gwright99/415 tighten studio ssh sg

### DIFF
--- a/000_main.tf
+++ b/000_main.tf
@@ -132,11 +132,12 @@ locals {
   sg_from_alb_core                      = try([module.sg_from_alb_core[0].security_group_id], [])
   sg_from_alb_connect                   = try([module.sg_from_alb_connect[0].security_group_id], [])
   sg_from_alb_wave                      = try([module.sg_from_alb_wave[0].security_group_id], [])
-  # Studios SSH — see 002_security_groups.tf for why two separate rules are needed
-  # (one for direct EC2 access, one for NLB path; NLBs don't have security groups
-  # so both use CIDR-based rules rather than source_security_group_id)
-  sg_ec2_noalb_ssh = try([module.sg_ec2_noalb_ssh[0].security_group_id], [])
-  sg_from_nlb_ssh  = try([module.sg_from_nlb_ssh[0].security_group_id], [])
+  sg_ec2_noalb_ssh                      = try([module.sg_ec2_noalb_ssh[0].security_group_id], [])
+  # Fix delay where Studio SSH rule doesn't show up until n+1 deploy after NLB created.
+  # Claude suggest "splat" as replacement for try().
+  # Explanation:  Splat gives you [] when count is 0 and [<id>] when count is 1, and propagates unknown values correctly when count is being changed in the current apply. Same shape, no try-on-unknown trap.
+  # sg_from_nlb_ssh  = try([module.sg_from_nlb_ssh[0].security_group_id], [])
+  sg_from_nlb_ssh = module.sg_from_nlb_ssh[*].security_group_id
 
   sg_ec2_final = concat(
     local.sg_ec2_core,
@@ -148,7 +149,6 @@ locals {
     local.sg_from_alb_wave,
     local.sg_ec2_noalb_ssh,
     local.sg_from_nlb_ssh,
-
   )
   ec2_sg_final_raw = join(",", [for sg in local.sg_ec2_final : jsonencode(sg)]) # Needed?
 

--- a/000_main.tf
+++ b/000_main.tf
@@ -132,11 +132,9 @@ locals {
   sg_from_alb_core                      = try([module.sg_from_alb_core[0].security_group_id], [])
   sg_from_alb_connect                   = try([module.sg_from_alb_connect[0].security_group_id], [])
   sg_from_alb_wave                      = try([module.sg_from_alb_wave[0].security_group_id], [])
-  sg_ec2_noalb_ssh                      = try([module.sg_ec2_noalb_ssh[0].security_group_id], [])
-  # Fix delay where Studio SSH rule doesn't show up until n+1 deploy after NLB created.
-  # Claude suggest "splat" as replacement for try().
-  # Explanation:  Splat gives you [] when count is 0 and [<id>] when count is 1, and propagates unknown values correctly when count is being changed in the current apply. Same shape, no try-on-unknown trap.
-  # sg_from_nlb_ssh  = try([module.sg_from_nlb_ssh[0].security_group_id], [])
+  # Studios SSH is NLB-only.
+  # Using 'splat' approach over 'try()' because try approach was causing attachment of SG to EC2 to be
+  # n+1 deployment versus creation of NLB.
   sg_from_nlb_ssh = module.sg_from_nlb_ssh[*].security_group_id
 
   sg_ec2_final = concat(
@@ -147,7 +145,6 @@ locals {
     local.sg_from_alb_core,
     local.sg_from_alb_connect,
     local.sg_from_alb_wave,
-    local.sg_ec2_noalb_ssh,
     local.sg_from_nlb_ssh,
   )
   ec2_sg_final_raw = join(",", [for sg in local.sg_ec2_final : jsonencode(sg)]) # Needed?

--- a/002_security_groups.tf
+++ b/002_security_groups.tf
@@ -3,7 +3,7 @@
 ## ------------------------------------------------------------------------------------
 /* 1. Modules rewritten May 15/2025 (combined ingress & egress).
 
-   2. Config entries like `ingress_with_cidr_blocks` require comma-delimited string, 
+   2. Config entries like `ingress_with_cidr_blocks` require comma-delimited string,
       whereas other config entries like `egress_rules` expect a list.
 
       To be reverse-compatible with existing installations, I've left tfvars keys as lists
@@ -146,7 +146,7 @@ module "sg_from_alb_core" {
 ## WHY THIS EXISTS:
 ##   When flag_create_load_balancer = false, there is no NLB in front of the EC2
 ##   instance. SSH traffic on port 2222 must be allowed directly from the permitted
-##   ingress CIDRs (sg_ingress_cidrs) to the EC2 instance.
+##   Studios SSH client CIDRs (var.sg_studio_ssh_cidrs) to the EC2 instance.
 ##
 ##   Docker's 2222:2222 port mapping in docker-compose.yml then forwards the traffic
 ##   from the EC2 host port into the connect-proxy container. The security group
@@ -154,10 +154,11 @@ module "sg_from_alb_core" {
 ##
 ## DIFFERENCE FROM sg_from_nlb_ssh (below):
 ##   This rule allows direct CIDR access. sg_from_nlb_ssh is used when an NLB is
-##   present (flag_create_load_balancer = true). Both use sg_ingress_cidrs because
-##   NLBs do not have security groups (unlike ALBs), so CIDR-based rules are required
-##   in both cases. They are kept as separate resources to follow the existing
-##   noalb / from_alb naming convention and count-gating pattern.
+##   present (flag_create_load_balancer = true); there the EC2 only accepts traffic
+##   from the NLB's security group, not from CIDRs directly. Both consume
+##   var.sg_studio_ssh_cidrs as the source-of-truth for "who can reach Studios SSH"
+##   — the difference is whether that CIDR list governs the EC2 SG directly (this
+##   resource) or the NLB SG (sg_nlb_ssh, which then fronts the EC2).
 ## ------------------------------------------------------------------------------------
 module "sg_ec2_noalb_ssh" {
   source  = "terraform-aws-modules/security-group/aws"
@@ -169,25 +170,50 @@ module "sg_ec2_noalb_ssh" {
   description = "Direct TCP (2222) traffic to EC2 for Studios SSH."
 
   vpc_id = local.vpc_id
-  # computed_ingress_with_cidr_blocks = [
-  #   {
-  #     from_port   = 2222
-  #     to_port     = 2222
-  #     protocol    = "tcp"
-  #     description = "Connect-Proxy SSH"
-  #     cidr_blocks = "${join(",", var.sg_ingress_cidrs)}"
-  #   }
-  # ]
   ingress_with_cidr_blocks = [
     {
       from_port   = 2222
       to_port     = 2222
       protocol    = "tcp"
-      description = "Connect-Proxy SSH via NLB"
-      cidr_blocks = join(",", var.sg_ingress_cidrs)
+      description = "Studios SSH client traffic (direct, no NLB)"
+      cidr_blocks = join(",", var.sg_studio_ssh_cidrs)
     }
   ]
   number_of_computed_ingress_with_source_security_group_id = 0
+}
+
+
+## ------------------------------------------------------------------------------------
+## SSH (Studios) — NLB security group
+##
+## WHY THIS EXISTS:
+##   AWS added security-group support for Network Load Balancers in August 2023.
+##   This SG is attached to the NLB itself (see aws_lb.nlb_ssh in 007_load_balancer.tf)
+##   and is the public-facing security boundary for Studios SSH: only clients in
+##   var.sg_studio_ssh_cidrs can reach the NLB on TCP 2222. The EC2 instance's own
+##   SG (sg_from_nlb_ssh below) then only accepts traffic from this SG — defence in
+##   depth, no CIDR-based rule on the EC2 itself.
+## ------------------------------------------------------------------------------------
+module "sg_nlb_ssh" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "5.1.0"
+
+  count = var.flag_create_load_balancer == true && var.flag_enable_data_studio_ssh == true ? 1 : 0
+
+  name        = "${local.global_prefix}_nlb_ssh"
+  description = "Allow inbound TCP 2222 from Studios SSH client CIDRs to the NLB."
+
+  vpc_id = local.vpc_id
+  ingress_with_cidr_blocks = [
+    {
+      from_port   = 2222
+      to_port     = 2222
+      protocol    = "tcp"
+      description = "Studios SSH client traffic"
+      cidr_blocks = join(",", var.sg_studio_ssh_cidrs)
+    }
+  ]
+  egress_rules = ["all-all"]
 }
 
 
@@ -201,20 +227,11 @@ module "sg_ec2_noalb_ssh" {
 ##   via the NLB created in 007_load_balancer.tf. The EC2 security group must allow
 ##   inbound TCP 2222 so the NLB can forward connections through.
 ##
-## WHY CIDR-BASED (NOT SOURCE SECURITY GROUP):
-##   ALBs have their own security groups, so sg_from_alb_connect can use
-##   source_security_group_id to restrict traffic to only what comes from the ALB.
-##   NLBs do NOT have security groups — traffic arrives at the EC2 instance from
-##   either the client IP or the NLB node IP depending on client IP preservation.
-##   CIDR-based rules (sg_ingress_cidrs) are therefore required.
-##
-## WHY VPC CIDR IS INCLUDED ALONGSIDE sg_ingress_cidrs:
-##   NLB health checks verify the target is alive by opening a TCP connection to
-##   port 2222 on the EC2 instance. The check originates from within
-##   the VPC — not from external IPs in sg_ingress_cidrs. If the VPC CIDR is not
-##   included, health checks are blocked, the target shows unhealthy, and the NLB
-##   stops forwarding real SSH traffic even though connect-proxy is running correctly.
-##   local.vpc_cidr_block is defined in 000_main.tf and handles both new and existing VPC.
+## WHY SOURCE-SG-BASED (NOT CIDR):
+##   AWS added SG support for NLBs in August 2023. sg_nlb_ssh (above) is attached to
+##   the NLB and is the public-facing boundary; this SG only allows traffic from
+##   sg_nlb_ssh — no CIDR rules on the EC2. NLB health checks also flow through
+##   the NLB's SG context, so a VPC CIDR carve-out is no longer required.
 ## ------------------------------------------------------------------------------------
 module "sg_from_nlb_ssh" {
   source  = "terraform-aws-modules/security-group/aws"
@@ -223,28 +240,19 @@ module "sg_from_nlb_ssh" {
   count = var.flag_create_load_balancer == true && var.flag_enable_data_studio_ssh == true ? 1 : 0
 
   name        = "${local.global_prefix}_from_nlb_ssh"
-  description = "Allow Studios SSH traffic via NLB on TCP 2222."
+  description = "Allow Studios SSH traffic on TCP 2222 from the NLB only."
 
   vpc_id = local.vpc_id
-  # computed_ingress_with_cidr_blocks = [
-  #   {
-  #     from_port   = 2222
-  #     to_port     = 2222
-  #     protocol    = "tcp"
-  #     description = "Connect-Proxy SSH via NLB"
-  #     cidr_blocks = "${join(",", var.sg_ingress_cidrs)}"
-  #   }
-  # ]
-  ingress_with_cidr_blocks = [
+  computed_ingress_with_source_security_group_id = [
     {
-      from_port   = 2222
-      to_port     = 2222
-      protocol    = "tcp"
-      description = "Connect-Proxy SSH via NLB"
-      cidr_blocks = join(",", distinct(concat(var.sg_ingress_cidrs, [local.vpc_cidr_block])))
+      from_port                = 2222
+      to_port                  = 2222
+      protocol                 = "tcp"
+      description              = "Connect-Proxy SSH via NLB"
+      source_security_group_id = module.sg_nlb_ssh[0].security_group_id
     }
   ]
-  number_of_computed_ingress_with_source_security_group_id = 0
+  number_of_computed_ingress_with_source_security_group_id = 1
 }
 
 
@@ -337,7 +345,7 @@ module "sg_db" {
       source_security_group_id = module.sg_ec2_core.security_group_id
     }
   ]
-  # TODO: Decide whether 
+  # TODO: Decide whether
   number_of_computed_ingress_with_source_security_group_id = 2
 }
 
@@ -421,7 +429,7 @@ what the impact would be on sites that:
 In order to support an orderly transition, I am reintroducing ALL the old 1.5.0 SGs. The reintroduction will ensure that any of the
 existing deloyments still find the assets they need prior to upgrade and then be able to transition to the new SG model introduced in 1.6.0.
 
-In a subsequent release, the resources below will be removed and documentation will clearly reflect that < 1.6.1 needs to upgrade to 1.6.1 
+In a subsequent release, the resources below will be removed and documentation will clearly reflect that < 1.6.1 needs to upgrade to 1.6.1
 prior to upgrading to any future release > 1.6.1
 
 */

--- a/002_security_groups.tf
+++ b/002_security_groups.tf
@@ -139,51 +139,6 @@ module "sg_from_alb_core" {
 
 
 ## ------------------------------------------------------------------------------------
-## SSH (Studios) — Direct EC2 access (no ALB/NLB)
-##
-## NOTE: This rule is the SSH equivalent of sg_ec2_noalb_connect above.
-##
-## WHY THIS EXISTS:
-##   When flag_create_load_balancer = false, there is no NLB in front of the EC2
-##   instance. SSH traffic on port 2222 must be allowed directly from the permitted
-##   Studios SSH client CIDRs (var.sg_studio_ssh_cidrs) to the EC2 instance.
-##
-##   Docker's 2222:2222 port mapping in docker-compose.yml then forwards the traffic
-##   from the EC2 host port into the connect-proxy container. The security group
-##   operates at the EC2 network level — before Docker sees the traffic.
-##
-## DIFFERENCE FROM sg_from_nlb_ssh (below):
-##   This rule allows direct CIDR access. sg_from_nlb_ssh is used when an NLB is
-##   present (flag_create_load_balancer = true); there the EC2 only accepts traffic
-##   from the NLB's security group, not from CIDRs directly. Both consume
-##   var.sg_studio_ssh_cidrs as the source-of-truth for "who can reach Studios SSH"
-##   — the difference is whether that CIDR list governs the EC2 SG directly (this
-##   resource) or the NLB SG (sg_nlb_ssh, which then fronts the EC2).
-## ------------------------------------------------------------------------------------
-module "sg_ec2_noalb_ssh" {
-  source  = "terraform-aws-modules/security-group/aws"
-  version = "5.1.0"
-
-  count = var.flag_create_load_balancer == false && var.flag_enable_data_studio_ssh == true ? 1 : 0
-
-  name        = "${local.global_prefix}_ec2_direct_ssh"
-  description = "Direct TCP (2222) traffic to EC2 for Studios SSH."
-
-  vpc_id = local.vpc_id
-  ingress_with_cidr_blocks = [
-    {
-      from_port   = 2222
-      to_port     = 2222
-      protocol    = "tcp"
-      description = "Studios SSH client traffic (direct, no NLB)"
-      cidr_blocks = join(",", var.sg_studio_ssh_cidrs)
-    }
-  ]
-  number_of_computed_ingress_with_source_security_group_id = 0
-}
-
-
-## ------------------------------------------------------------------------------------
 ## SSH (Studios) — NLB security group
 ##
 ## WHY THIS EXISTS:
@@ -218,20 +173,13 @@ module "sg_nlb_ssh" {
 
 
 ## ------------------------------------------------------------------------------------
-## SSH (Studios) — via NLB (flag_create_load_balancer = true)
+## SSH (Studios) — EC2 ingress from NLB
 ##
-## NOTE: This rule is the SSH equivalent of sg_from_alb_connect below.
-##
-## WHY THIS EXISTS:
-##   When flag_create_load_balancer = true, SSH traffic arrives at the EC2 instance
-##   via the NLB created in 007_load_balancer.tf. The EC2 security group must allow
-##   inbound TCP 2222 so the NLB can forward connections through.
-##
-## WHY SOURCE-SG-BASED (NOT CIDR):
-##   AWS added SG support for NLBs in August 2023. sg_nlb_ssh (above) is attached to
-##   the NLB and is the public-facing boundary; this SG only allows traffic from
-##   sg_nlb_ssh — no CIDR rules on the EC2. NLB health checks also flow through
-##   the NLB's SG context, so a VPC CIDR carve-out is no longer required.
+## Studios SSH is NLB-only.
+## All Studios SSH traffic enters via the NLB created in 007_load_balancer.tf; this SG allows
+## the EC2 to accept that traffic from the NLB's own security group (sg_nlb_ssh above) —
+## no CIDR-based rules on the EC2. NLB health checks also flow through the NLB SG
+## context, so a VPC-CIDR carve-out is unnecessary.
 ## ------------------------------------------------------------------------------------
 module "sg_from_nlb_ssh" {
   source  = "terraform-aws-modules/security-group/aws"

--- a/007_load_balancer.tf
+++ b/007_load_balancer.tf
@@ -160,16 +160,11 @@ module "alb" {
 ## NLB — Data Studios SSH
 ##
 ## WHY A SEPARATE NLB:
-##   The ALB above is a Layer 7 (HTTP/HTTPS) load balancer. It cannot handle raw TCP
-##   traffic. SSH operates at Layer 4 (raw TCP) on port 2222, so it requires a Network
-##   Load Balancer (NLB) to pass TCP connections through to connect-proxy on the EC2
-##   instance.
+##   The ALB above is a Layer 7 (HTTP/HTTPS) load balancer; SSH is raw TCP (Layer 4)
+##   on port 2222 and requires a Network Load Balancer for passthrough to connect-proxy
+##   on the EC2 instance.
 ##
-##   The NLB is only created when flag_enable_data_studio_ssh = true AND
-##   flag_create_load_balancer = true. If flag_create_load_balancer = false, no NLB
-##   is created — instead, a Route53 A record points connect-ssh.<tower_server_url>
-##   directly to the EC2 instance IP (see 008_route53.tf aws_route53_record.ec2_ssh).
-##   SSH still works in that case via direct EC2 access on port 2222.
+##   Studios SSH is NLB-only.
 ##
 ## WHAT IT DOES:
 ##   - Creates an NLB listening on TCP port 2222

--- a/007_load_balancer.tf
+++ b/007_load_balancer.tf
@@ -183,10 +183,16 @@ module "alb" {
 resource "aws_lb" "nlb_ssh" {
   count = var.flag_enable_data_studio_ssh && var.flag_create_load_balancer ? 1 : 0
 
-  name               = "${local.global_prefix}-ssh"
+  name               = "${substr(local.global_prefix, 0, 28)}-ssh"
   load_balancer_type = "network"
   internal           = var.flag_make_instance_private == true || var.flag_private_tower_without_eice == true ? true : false
   subnets            = module.subnet_collector.subnet_ids_alb
+
+  # AWS added security-group support to NLBs in August 2023. The NLB is the public-facing
+  # boundary for Studios SSH — only clients in var.sg_studio_ssh_cidrs can reach it
+  # (enforced by sg_nlb_ssh). The EC2 SG (sg_from_nlb_ssh) only allows traffic from this
+  # SG, not from CIDRs. See 002_security_groups.tf.
+  security_groups = [module.sg_nlb_ssh[0].security_group_id]
 }
 
 resource "aws_lb_target_group" "nlb_ssh" {

--- a/008_route53.tf
+++ b/008_route53.tf
@@ -90,10 +90,8 @@ resource "aws_route53_record" "ec2_connect" {
 }
 
 
-# Tower Connect SSH
-# NLB record (flag_create_load_balancer = true): points to the NLB for TCP passthrough on port 2222.
-# EC2 record (flag_create_load_balancer = false): points directly to the EC2 instance IP.
-# Both resolve to connect-ssh.<tower_server_url>, which Platform shows users as the SSH address.
+# Tower Connect SSH — NLB-only path. Resolves connect-ssh.<tower_server_url> to the NLB
+# created in 007_load_balancer.tf for TCP passthrough on port 2222.
 resource "aws_route53_record" "nlb_ssh" {
   count = local.dns_create_alb_record == true && var.flag_enable_data_studio_ssh == true ? 1 : 0
 
@@ -106,17 +104,6 @@ resource "aws_route53_record" "nlb_ssh" {
     zone_id                = aws_lb.nlb_ssh[0].zone_id
     evaluate_target_health = true
   }
-}
-
-resource "aws_route53_record" "ec2_ssh" {
-  count = local.dns_create_ec2_record == true && var.flag_enable_data_studio_ssh == true ? 1 : 0
-
-  zone_id = local.dns_zone_id
-  name    = module.connection_strings.tower_connect_ssh_dns
-  type    = "A"
-
-  ttl     = "5"
-  records = [local.dns_instance_ip]
 }
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - Added logger config in `tower.yml` to disable noisy (but benign) JWT validation stack traces.
             - Security groups now attach to the EC2 instance directly, not only via the launch template — toggling SG-gating flags (e.g., `flag_enable_data_studio_ssh`) after the initial deploy now propagates to running instances on the next `terraform apply`. Affected sites will see a one-time in-place SG attachment update with no instance replacement. [`#404`](https://github.com/seqeralabs/cx-field-tools-installer/issues/404)
 
+    - Security
+        - Restricted Studios SSH (port 2222) ingress so the EC2 SG only accepts traffic from the NLB's own security group instead of from `var.sg_ingress_cidrs` directly. Previously, deployers using `sg_ingress_cidrs = ["0.0.0.0/0"]` for general HTTP traffic were also exposing SSH to the world. New `sg_studio_ssh_cidrs` tfvars variable is the source-of-truth for "who can reach Studios SSH" — governs the NLB SG when an LB is in use, governs the EC2 SG directly when not. `check_configuration.py` fails at plan time if `flag_enable_data_studio_ssh = true` and `sg_studio_ssh_cidrs` is empty. **Existing sites with Studios SSH enabled will see the affected security groups replaced on next apply** (the underlying rules change shape from CIDR-based to source-SG-based).
+
     - Documentation
         - Fixed `pipeline_versioning_eligible_workspaces` default value in `TEMPLATE_terraform.tfvars` from `null` to `""`. [`#401`](https://github.com/seqeralabs/cx-field-tools-installer/issues/401)
 
@@ -24,6 +27,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
 #### `terraform.tfvars`
 | Status | Component | Parameter Name | Description |
 | ------ | --------- | -------------- | ----------- |
+| New | Studios SSH | `sg_studio_ssh_cidrs` | List of CIDRs allowed to reach Studios SSH on TCP 2222. Required (non-empty) when `flag_enable_data_studio_ssh = true`. When `flag_create_load_balancer = true`, governs the NLB's security group; when `false`, governs the EC2 security group directly. Validated at plan time by `check_configuration.py`. |
 | Modified | Platform | `pipeline_versioning_eligible_workspaces` | Corrected default value from `null` to `""`. Deployers with `null` set should update to `""` to avoid unexpected behaviour in template rendering. [`#401`](https://github.com/seqeralabs/cx-field-tools-installer/issues/401) |
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
             - Security groups now attach to the EC2 instance directly, not only via the launch template — toggling SG-gating flags (e.g., `flag_enable_data_studio_ssh`) after the initial deploy now propagates to running instances on the next `terraform apply`. Affected sites will see a one-time in-place SG attachment update with no instance replacement. [`#404`](https://github.com/seqeralabs/cx-field-tools-installer/issues/404)
 
     - Security
-        - Restricted Studios SSH (port 2222) ingress so the EC2 SG only accepts traffic from the NLB's own security group instead of from `var.sg_ingress_cidrs` directly. Previously, deployers using `sg_ingress_cidrs = ["0.0.0.0/0"]` for general HTTP traffic were also exposing SSH to the world. New `sg_studio_ssh_cidrs` tfvars variable is the source-of-truth for "who can reach Studios SSH" — governs the NLB SG when an LB is in use, governs the EC2 SG directly when not. `check_configuration.py` fails at plan time if `flag_enable_data_studio_ssh = true` and `sg_studio_ssh_cidrs` is empty. **Existing sites with Studios SSH enabled will see the affected security groups replaced on next apply** (the underlying rules change shape from CIDR-based to source-SG-based).
+        - Restricted Studios SSH (port 2222) ingress so the EC2 SG only accepts traffic from the NLB's own security group instead of from `var.sg_ingress_cidrs` directly. Previously, deployers using `sg_ingress_cidrs = ["0.0.0.0/0"]` for general HTTP traffic were also exposing SSH to the world. New `sg_studio_ssh_cidrs` tfvars variable is the source-of-truth for "who can reach Studios SSH" and governs the NLB's security group. `check_configuration.py` fails at plan time if `flag_enable_data_studio_ssh = true` and `sg_studio_ssh_cidrs` is empty. **Existing sites with Studios SSH enabled will see the affected security groups replaced on next apply** (the underlying rules change shape from CIDR-based to source-SG-based).
+        - **Breaking change.** Studios SSH is now NLB-only. Removed the previously-undocumented direct-to-EC2 path (`module.sg_ec2_noalb_ssh`). No documented or tested deployments used this combo, so impact is expected to be zero, but flagging as breaking for honesty's sake.
 
     - Documentation
         - Fixed `pipeline_versioning_eligible_workspaces` default value in `TEMPLATE_terraform.tfvars` from `null` to `""`. [`#401`](https://github.com/seqeralabs/cx-field-tools-installer/issues/401)
@@ -27,7 +28,7 @@ $ git log origin/master..origin/gwright99/25_2_0_update --oneline
 #### `terraform.tfvars`
 | Status | Component | Parameter Name | Description |
 | ------ | --------- | -------------- | ----------- |
-| New | Studios SSH | `sg_studio_ssh_cidrs` | List of CIDRs allowed to reach Studios SSH on TCP 2222. Required (non-empty) when `flag_enable_data_studio_ssh = true`. When `flag_create_load_balancer = true`, governs the NLB's security group; when `false`, governs the EC2 security group directly. Validated at plan time by `check_configuration.py`. |
+| New | Studios SSH | `sg_studio_ssh_cidrs` | List of CIDRs allowed to reach Studios SSH on TCP 2222. Required (non-empty) when `flag_enable_data_studio_ssh = true`. Governs the NLB's security group. Validated at plan time by `check_configuration.py`. |
 | Modified | Platform | `pipeline_versioning_eligible_workspaces` | Corrected default value from `null` to `""`. Deployers with `null` set should update to `""` to avoid unexpected behaviour in template rendering. [`#401`](https://github.com/seqeralabs/cx-field-tools-installer/issues/401) |
 
 

--- a/scripts/installer/validation/check_configuration.py
+++ b/scripts/installer/validation/check_configuration.py
@@ -189,8 +189,7 @@ def verify_data_lineage_enabled(data: SimpleNamespace):
 def verify_studio_ssh_cidrs_set(data: SimpleNamespace):
     """Fail if Studios SSH is enabled but no client CIDRs were configured.
 
-    `sg_studio_ssh_cidrs` is the source-of-truth for who can reach Studios SSH (it
-    governs the NLB SG when an LB is used, and the EC2 SG directly when not). An empty
+    `sg_studio_ssh_cidrs` is the source-of-truth for who can reach Studios SSH. An empty
     list combined with `flag_enable_data_studio_ssh = true` would silently create a
     deployment with no working SSH access — fail loudly at validation instead.
     """

--- a/scripts/installer/validation/check_configuration.py
+++ b/scripts/installer/validation/check_configuration.py
@@ -186,6 +186,22 @@ def verify_data_lineage_enabled(data: SimpleNamespace):
         log_error_and_exit("Data lineage can only be enabled on Platform v26.1.0+")
 
 
+def verify_studio_ssh_cidrs_set(data: SimpleNamespace):
+    """Fail if Studios SSH is enabled but no client CIDRs were configured.
+
+    `sg_studio_ssh_cidrs` is the source-of-truth for who can reach Studios SSH (it
+    governs the NLB SG when an LB is used, and the EC2 SG directly when not). An empty
+    list combined with `flag_enable_data_studio_ssh = true` would silently create a
+    deployment with no working SSH access — fail loudly at validation instead.
+    """
+    if data.flag_enable_data_studio_ssh and not data.sg_studio_ssh_cidrs:
+        log_error_and_exit(
+            "flag_enable_data_studio_ssh = true requires `sg_studio_ssh_cidrs` to be set "
+            "to a non-empty list of CIDRs. This list defines which clients can reach "
+            "Studios SSH (port 2222)."
+        )
+
+
 def verify_aws_instance_credentials_platform_version(data: SimpleNamespace):
     """Reject AWS instance credentials on Platform versions with the known bug.
 
@@ -639,6 +655,7 @@ if __name__ == "__main__":
     verify_email_login_disablement(data)
     verify_workflow_cleanup_enabled(data)
     verify_data_lineage_enabled(data)
+    verify_studio_ssh_cidrs_set(data)
     verify_aws_instance_credentials_platform_version(data)
     verify_compute_env_cleanup_platform_version(data)
     verify_audit_log_v2_platform_version(data)

--- a/templates/TEMPLATE_terraform.tfvars
+++ b/templates/TEMPLATE_terraform.tfvars
@@ -374,11 +374,10 @@ See: https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/
 sg_ingress_cidrs = ["0.0.0.0/0"]
 sg_ssh_cidrs     = ["0.0.0.0/0"]
 
-# CIDRs allowed to reach Studios SSH (port 2222). When flag_enable_data_studio_ssh = true
-# AND flag_create_load_balancer = true, this governs the NLB's own security group. When
-# flag_enable_data_studio_ssh = true AND flag_create_load_balancer = false, this governs
-# the EC2 SG directly. Must be non-empty when Studios SSH is enabled (validated at plan
-# time by check_configuration.py).
+# CIDRs allowed to reach Studios SSH (port 2222). Governs the NLB's own security group.
+# Studios SSH is NLB-only: flag_enable_data_studio_ssh = true requires
+# flag_create_load_balancer = true. Must be non-empty when Studios SSH is enabled
+# (validated at plan time by check_configuration.py).
 sg_studio_ssh_cidrs = ["0.0.0.0/0"]
 
 sg_egress_eice               = ["all-all"]

--- a/templates/TEMPLATE_terraform.tfvars
+++ b/templates/TEMPLATE_terraform.tfvars
@@ -374,6 +374,13 @@ See: https://github.com/terraform-aws-modules/terraform-aws-security-group/blob/
 sg_ingress_cidrs = ["0.0.0.0/0"]
 sg_ssh_cidrs     = ["0.0.0.0/0"]
 
+# CIDRs allowed to reach Studios SSH (port 2222). When flag_enable_data_studio_ssh = true
+# AND flag_create_load_balancer = true, this governs the NLB's own security group. When
+# flag_enable_data_studio_ssh = true AND flag_create_load_balancer = false, this governs
+# the EC2 SG directly. Must be non-empty when Studios SSH is enabled (validated at plan
+# time by check_configuration.py).
+sg_studio_ssh_cidrs = ["0.0.0.0/0"]
+
 sg_egress_eice               = ["all-all"]
 sg_egress_tower_ec2          = ["all-all"]
 sg_egress_tower_alb          = ["all-all"]

--- a/variables.tf
+++ b/variables.tf
@@ -208,6 +208,7 @@ variable "vpc_interface_endpoints_batch" { type = list(any) }
 
 variable "sg_ingress_cidrs" { type = list(string) }
 variable "sg_ssh_cidrs" { type = list(string) }
+variable "sg_studio_ssh_cidrs" { type = list(string) }
 
 variable "sg_egress_eice" { type = list(string) }
 variable "sg_egress_tower_ec2" { type = list(string) }


### PR DESCRIPTION
## Summary

Studio SSH groups were too open. This PR tightens them and rips out the non-NLB flow.

## Related Issues

- See #415 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Breaking change
- [ ] Refactor / chore
- [ ] Documentation
- [ ] Tests

## Changes

- Adds `terraform.tfvars` value to defined allows Studios SSH CIDRs (_this must be different than the "SSH CIDRs for administrators").
- Creates NLB SG that accepts traffic only from the defined CIDRs in the tfvar.
- Makes EC2 SG only accept traffic on 2222 from NLB SG.
- Removes option to deploy Studios SSH without an NLB.

## Test Plan

- Deploy with allowed Studio SSh CIDR of `0.0.0.0/0`. Confirm connection to a running Studio.
- Redeploy with allowed Studio SSh CIDR of `10.0.0.0/0`. Confirm connection to a running Studio is denied.

- [ ] `make verify` passes
- [ ] `make plan` reviewed
- [x] `./tests/run_tests_all.sh` passes
- [ ] Unit tests added/updated
- [x] Integration tested against a live deployment
- [ ] `ruff` run on modified Python files

## Configuration / Migration Notes

Any client that has already deployed Studios SSH (NLB) _without_ SG will need to taint and recreate their NLB instance.

## Screenshots / Output

n/a

## Checklist

- [x] Updated `templates/TEMPLATE_terraform.tfvars` if variables changed
- [x] Updated CHANGELOG / VERSION if applicable
- [ ] No secrets committed; sensitive values use SSM Parameter Store
- [x] Documentation updated (README, CLAUDE.md, inline docs)
